### PR TITLE
actually create the database in the closest region

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -137,7 +137,7 @@ var createCmd = &cobra.Command{
 		}
 		region := region
 		if region == "" {
-			region = "ams"
+                   region = probeClosestRegion()
 		}
 		accessToken, err := getAccessToken()
 		if err != nil {


### PR DESCRIPTION
turso db regions shows a default region, but db create is still creating default AMS.