### PR TITLE
Fix writting settings

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -43,7 +43,7 @@ func (s *Settings) AddDatabase(name string, dbSettings *DatabaseSettings) {
 	databases := viper.GetStringMap("databases")
 	databases[name] = dbSettings
 	viper.Set("databases", databases)
-	viper.SafeWriteConfig()
+	viper.WriteConfig()
 }
 
 func (s *Settings) GetDatabaseSettings(name string) *DatabaseSettings {


### PR DESCRIPTION
SafeWriteConfig only writes config if the file does not exist. WriteConfig should be used to update the file.

Fixes #47

Signed-off-by: Piotr Jastrzebski <piotr@chiselstrike.com>