### PR TITLE
Show https URL in `turso db create`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.env
 dist/
 completions
 internal/cmd/version.txt

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -29,7 +29,7 @@ func (s *DatabaseSettings) GetURL() string {
 	} else {
 		hostname = s.Host
 	}
-	return fmt.Sprintf("http://%s:%s@%s", s.Username, s.Password, hostname)
+	return fmt.Sprintf("https://%s:%s@%s", s.Username, s.Password, hostname)
 }
 
 type Settings struct{}


### PR DESCRIPTION
Depends on [iku-turso-api#51](https://github.com/chiselstrike/iku-turso-api/pull/51).