### PR TITLE
Improve error messages when provided db name is wrong.

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -88,9 +88,9 @@ func getDatabaseURL(name string) (string, error) {
 	_, err = url.ParseRequestURI(name)
 	var dbUrl string
 	if err != nil {
-		dbSettings := config.FindDatabaseByName(name)
-		if dbSettings == nil {
-			return "", fmt.Errorf("database %s not found", name)
+		dbSettings, err := config.FindDatabaseByName(name)
+		if err != nil {
+			return "", fmt.Errorf("provided identifier '%s' is neither a valid url, nor known database name: %s", name, err.Error())
 		}
 		dbUrl = dbSettings.GetURL()
 	} else {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kirsle/configdir"
@@ -98,16 +99,19 @@ func (s *Settings) AddDatabase(id string, dbSettings *DatabaseSettings) {
 	}
 }
 
-func (s Settings) FindDatabaseByName(name string) *DatabaseSettings {
+func (s Settings) FindDatabaseByName(name string) (*DatabaseSettings, error) {
 	databases := viper.GetStringMap("databases")
+	db_names := make([]string, 0)
 	for _, rawSettings := range databases {
 		settings := DatabaseSettings{}
 		mapstructure.Decode(rawSettings, &settings)
 		if settings.Name == name {
-			return &settings
+			return &settings, nil
 		}
+		db_names = append(db_names, fmt.Sprintf("'%s'", settings.Name))
 	}
-	return nil
+	return nil, fmt.Errorf("provided database name is unknown. Valid database names are: [%s]",
+		strings.Join(db_names, ","))
 }
 
 func (s *Settings) GetDatabaseSettings(id string) *DatabaseSettings {


### PR DESCRIPTION
Fixes https://github.com/chiselstrike/iku-turso-cli/issues/98. Instead of the crash, the user gets an error message: `Error: provided identifier '127.0.0.1:8080' is neither a valid url, nor known database name: provided database name is unknown. Valid database names are: []`
