### PR TITLE
Silence usage printing

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -13,6 +13,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	rootCmd.SilenceUsage = true
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Let's disable usage printing on error by default and instead handle it case-by-case basis in individual commands if needed.

Fixes #57