### PR TITLE
db auth: Fix message when already logged in

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -75,7 +75,6 @@ func isJwtTokenValid(token string) bool {
 }
 
 func login(cmd *cobra.Command, args []string) error {
-	fmt.Println("Waiting for authentication...")
 	settings, err := settings.ReadSettings()
 	if err != nil {
 		return fmt.Errorf("could not retrieve local config: %w", err)
@@ -84,6 +83,7 @@ func login(cmd *cobra.Command, args []string) error {
 		fmt.Println("✔  Success! Existing JWT still valid")
 		return nil
 	}
+	fmt.Println("Waiting for authentication...")
 	ch := make(chan string, 1)
 	server, err := createCallbackServer(ch)
 	if err != nil {


### PR DESCRIPTION
Before:

```console
$ turso auth login
Waiting for authentication...
✔  Success! Existing JWT still valid
```
After:

```console
$ turso auth login
✔  Success! Existing JWT still valid
```