### PR TITLE
Always stop spinners

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -184,6 +184,7 @@ var createCmd = &cobra.Command{
 		regionText := fmt.Sprintf("%s (%s)", toLocation(region), region)
 		description := fmt.Sprintf("Creating database %s in %s ", emph(name), emph(regionText))
 		bar := startLoadingBar(description)
+		defer bar.Stop()
 		res, err := client.Databases.Create(name, region, image)
 		if err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -156,6 +156,7 @@ func startLoadingBar(text string) *spinner.Spinner {
 func destroyDatabase(client *turso.Client, name string) error {
 	start := time.Now()
 	s := startSpinner(fmt.Sprintf("Destroying database %s... ", emph(name)))
+	defer s.Stop()
 	if err := client.Databases.Delete(name); err != nil {
 		return err
 	}


### PR DESCRIPTION
Before:
```
➜  iku-turso-cli git:(main) go run ./cmd/turso db create DSNIUADNIUAS
Creating database DSNIUADNIUAS in São Paulo, Brazil (gru) [                    ]Error: could not create database DSNIUADNIUAS: database name may only contain numbers, lowercase letters and dashes
exit status 1 
```

After: 
```
➜  iku-turso-cli git:(main) ✗ go run ./cmd/turso db create DSNIUADNIUAS
Error: could not create database DSNIUADNIUAS: database name may only contain numbers, lowercase letters and dashes
exit status 1
```