### PR TITLE
Remove workaround to properly delete instances

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -223,13 +223,9 @@ func destroyDatabaseInstance(client *turso.Client, database, instance string) er
 }
 
 func deleteDatabaseInstance(client *turso.Client, database, instance string) error {
-	if err := client.Instances.Delete(database, instance); err != nil {
-		// TODO: remove this once wait stopped bug is fixed
-		time.Sleep(3 * time.Second)
-		err = client.Instances.Delete(database, instance)
-		if err != nil {
-			return fmt.Errorf("could not delete instance %s: %w", instance, err)
-		}
+	err := client.Instances.Delete(database, instance)
+	if err != nil {
+		return fmt.Errorf("could not delete instance %s: %w", instance, err)
 	}
 	return nil
 }


### PR DESCRIPTION
It isn't needed anymore since the API is fixed.

Depends on https://github.com/chiselstrike/iku-turso-api/pull/110.