### PR TITLE
Fix error strings

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -52,7 +52,7 @@ var tokenCmd = &cobra.Command{
 		}
 		token := settings.GetToken()
 		if !isJwtTokenValid(token) {
-			return fmt.Errorf("No user logged in. Run `turso auth login` to log in and get a token.")
+			return fmt.Errorf("no user logged in. Run `turso auth login` to log in and get a token")
 		}
 		fmt.Println(token)
 		return nil
@@ -87,17 +87,17 @@ func login(cmd *cobra.Command, args []string) error {
 	ch := make(chan string, 1)
 	server, err := createCallbackServer(ch)
 	if err != nil {
-		return fmt.Errorf("Internal error. Cannot create callback: %w", err)
+		return fmt.Errorf("internal error. Cannot create callback: %w", err)
 	}
 
 	port, err := runServer(server)
 	if err != nil {
-		return fmt.Errorf("Internal error. Cannot run authentication server: %w", err)
+		return fmt.Errorf("internal error. Cannot run authentication server: %w", err)
 	}
 
 	err = beginAuth(port)
 	if err != nil {
-		return fmt.Errorf("Internal error. Cannot initiate auth flow: %w", err)
+		return fmt.Errorf("internal error. Cannot initiate auth flow: %w", err)
 	}
 
 	jwt := <-ch

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -36,15 +36,15 @@ var replicateCmd = &cobra.Command{
 		}
 		name := args[0]
 		if name == "" {
-			return fmt.Errorf("You must specify a database name to replicate it.")
+			return fmt.Errorf("you must specify a database name to replicate it")
 		}
 		region := args[1]
 		if region == "" {
-			return fmt.Errorf("You must specify a database region ID to replicate it.")
+			return fmt.Errorf("you must specify a database region ID to replicate it")
 		}
 		tursoClient := createTursoClient()
 		if !isValidRegion(tursoClient, region) {
-			return fmt.Errorf("Invalid region ID. Run %s to see a list of valid region IDs.", turso.Emph("turso db regions"))
+			return fmt.Errorf("invalid region ID. Run %s to see a list of valid region IDs", turso.Emph("turso db regions"))
 		}
 		var image string
 		if canary {
@@ -87,10 +87,10 @@ var replicateCmd = &cobra.Command{
 		resp, err := client.Do(req)
 		s.Stop()
 		if err != nil {
-			return fmt.Errorf("Failed to create database: %s", err)
+			return fmt.Errorf("failed to create database: %s", err)
 		}
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Failed to create database: %s", resp.Status)
+			return fmt.Errorf("failed to create database: %s", resp.Status)
 		}
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -45,7 +45,7 @@ var shellCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		if name == "" {
-			return fmt.Errorf("Please specify a database name.")
+			return fmt.Errorf("please specify a database name")
 		}
 		dbUrl, err := getDatabaseURL(name)
 		if err != nil {


### PR DESCRIPTION
The `staticcheck` tools points out the following issues in some of our error strings:

  error strings should not be capitalized (ST1005)
  error strings should not end with punctuation or newlines (ST1005)