### PR TITLE
Print usage info when usage is incorrect

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -46,6 +46,7 @@ var tokenCmd = &cobra.Command{
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		settings, err := settings.ReadSettings()
 		if err != nil {
 			return fmt.Errorf("could not retrieve local config: %w", err)
@@ -75,6 +76,7 @@ func isJwtTokenValid(token string) bool {
 }
 
 func login(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	settings, err := settings.ReadSettings()
 	if err != nil {
 		return fmt.Errorf("could not retrieve local config: %w", err)
@@ -161,6 +163,7 @@ func runServer(server *http.Server) (int, error) {
 }
 
 func logout(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	settings, err := settings.ReadSettings()
 	if err != nil {
 		return fmt.Errorf("could not retrieve local config: %w", err)

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -16,6 +16,7 @@ var createCmd = &cobra.Command{
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		config, err := settings.ReadSettings()
 		if err != nil {
 			return err

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -20,6 +20,7 @@ var destroyCmd = &cobra.Command{
 	Args:              cobra.MatchAll(cobra.ExactArgs(1), dbNameValidator(0)),
 	ValidArgsFunction: destroyArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		client := createTursoClient()
 		name := args[0]
 		if instanceFlag != "" {

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -11,6 +11,7 @@ var listCmd = &cobra.Command{
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		settings, err := settings.ReadSettings()
 		if err != nil {
 			return err

--- a/internal/cmd/db_regions.go
+++ b/internal/cmd/db_regions.go
@@ -13,6 +13,7 @@ var regionsCmd = &cobra.Command{
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		client := createTursoClient()
 		regions, err := turso.GetRegions(client)
 		if err != nil {

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -30,10 +30,6 @@ var replicateCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(2),
 	ValidArgsFunction: replicateArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		config, err := settings.ReadSettings()
-		if err != nil {
-			return err
-		}
 		name := args[0]
 		if name == "" {
 			return fmt.Errorf("you must specify a database name to replicate it")
@@ -41,6 +37,11 @@ var replicateCmd = &cobra.Command{
 		region := args[1]
 		if region == "" {
 			return fmt.Errorf("you must specify a database region ID to replicate it")
+		}
+		cmd.SilenceUsage = true
+		config, err := settings.ReadSettings()
+		if err != nil {
+			return err
 		}
 		tursoClient := createTursoClient()
 		if !isValidRegion(tursoClient, region) {

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -47,6 +47,7 @@ var shellCmd = &cobra.Command{
 		if name == "" {
 			return fmt.Errorf("please specify a database name")
 		}
+		cmd.SilenceUsage = true
 		dbUrl, err := getDatabaseURL(name)
 		if err != nil {
 			return err

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -17,6 +17,7 @@ var showCmd = &cobra.Command{
 		dbNameValidator(0),
 	),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		client := createTursoClient()
 		db, err := getDatabase(client, args[0])
 		if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -13,7 +13,6 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	rootCmd.SilenceUsage = true
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Previously we were always silencing usage and not printing it on error.
This commit silences usage only after the usage is checked so that we will print usage info on incorrect usage but not on other errors.

The way this is achieved is by not silencing usage on the root command and instead setting `SilenceUsage` to `true` at the beginning of `RunE` method of each leaf command. This method is executed after the usage is checked for correctness by Cobra.

Fixes #128
Fixes #132

Signed-off-by: Piotr Jastrzebski <piotr@chiselstrike.com>