### PR TITLE
Improve the error message for first time CLI users

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -71,8 +71,8 @@ var createCmd = &cobra.Command{
 
 		fmt.Printf("You can start an interactive SQL shell with:\n\n")
 		fmt.Printf("   turso db shell %s\n\n", name)
-		fmt.Printf("To obtain connection URL, run:\n\n")
-		fmt.Printf("   turso db show --url %s\n\n", name)
+		fmt.Printf("To see information about the database, including a connection URL, run:\n\n")
+		fmt.Printf("   turso db show %s\n\n", name)
 		config.AddDatabase(res.Database.ID, &dbSettings)
 		config.InvalidateDbNamesCache()
 		return nil


### PR DESCRIPTION
The rationale here is that they are more likely to find the entire output of `turso db show` more helpful than just the URL.  The URL alone is probably most useful only in scripting/automation situations.