### PR TITLE
Hide 'completion' command from users

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -30,4 +30,5 @@ func init() {
 	if err := viper.BindPFlag("config-path", rootCmd.PersistentFlags().Lookup("config-path")); err != nil {
 		fmt.Fprintf(os.Stderr, "error binding token flag: %s", err)
 	}
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 }


### PR DESCRIPTION
The 'completion' command is an internal command that the user doesn't really need to discover on their own. Let's hide it.