### PR TITLE
Rename 'change-password' to 'passwd'

### DIFF
--- a/internal/cmd/db_passwd.go
+++ b/internal/cmd/db_passwd.go
@@ -17,7 +17,7 @@ func changePasswordShellArgs(cmd *cobra.Command, args []string, toComplete strin
 }
 
 var changePasswordCmd = &cobra.Command{
-	Use:               "change-password database_name",
+	Use:               "passwd database_name",
 	Short:             "Change password to all instances of the database",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: changePasswordShellArgs,

--- a/testing/database_test.go
+++ b/testing/database_test.go
@@ -167,7 +167,7 @@ func TestDbReplication(t *testing.T) {
 }
 
 func changePassword(c *qt.C, dbName string, configPath *string, newPassword string) {
-	turso(configPath, "db", "change-password", dbName, "-p", newPassword)
+	turso(configPath, "db", "passwd", dbName, "-p", newPassword)
 }
 
 func TestChangeDbPassword(t *testing.T) {


### PR DESCRIPTION
The 'passwd' command is the standard command for modifying your password, so let's use that instead of the longer 'change-password' command name.