### PR TITLE
Add "turso account show" command

### DIFF
--- a/internal/cmd/account.go
+++ b/internal/cmd/account.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Manage your account plan and billing",
+}
+
+func init() {
+	rootCmd.AddCommand(accountCmd)
+	accountCmd.AddCommand(accountShowCmd)
+}

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/spf13/cobra"
+)
+
+var accountShowCmd = &cobra.Command{
+	Use:               "show",
+	Short:             "Show your current account plan.",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		fmt.Printf("Your are currently on %s plan.\n", turso.Emph("starter"))
+		fmt.Println()
+		fmt.Println("Storage: 5 GiB")
+		return nil
+	},
+}


### PR DESCRIPTION
This adds a "turso account show" command, which displays the following:

```
Your are currently on starter plan.

Storage: 5 GiB
```

The text is static for now, but we need to:

- Add plans to the Turso API
- Track how much storage is used and show it
- Track how many rows read and written and show it