### PR TITLE
db show: Add '--basic-auth' option

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -11,6 +11,7 @@ import (
 )
 
 var showUrlFlag bool
+var showBasicAuthFlag bool
 var showHttpUrlFlag bool
 var showInstanceUrlFlag string
 var passwordFlag string

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -26,7 +26,7 @@ var listCmd = &cobra.Command{
 		}
 		data := [][]string{}
 		for _, database := range databases {
-			url := getDatabaseUrl(settings, &database)
+			url := getDatabaseUrl(settings, &database, false)
 			regions := getDatabaseRegions(database)
 			data = append(data, []string{database.Name, regions, url})
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -17,6 +17,7 @@ import (
 func init() {
 	dbCmd.AddCommand(showCmd)
 	showCmd.Flags().BoolVar(&showUrlFlag, "url", false, "Show URL for the database HTTP API.")
+	showCmd.Flags().BoolVar(&showBasicAuthFlag, "basic-auth", false, "Show basic authentication in the URL.")
 	showCmd.Flags().StringVar(&showInstanceUrlFlag, "instance-url", "", "Show URL for the HTTP API of a selected instance of a database. Instance is selected by instance name.")
 	showCmd.RegisterFlagCompletionFunc("instance-url", completeInstanceName)
 	showCmd.RegisterFlagCompletionFunc("instance-ws-url", completeInstanceName)
@@ -48,7 +49,7 @@ var showCmd = &cobra.Command{
 		}
 
 		if showUrlFlag {
-			fmt.Println(getDatabaseUrl(config, &db))
+			fmt.Println(getDatabaseUrl(config, &db, showBasicAuthFlag))
 			return nil
 		}
 
@@ -77,7 +78,7 @@ var showCmd = &cobra.Command{
 		sort.Strings(regions)
 
 		fmt.Println("Name:          ", db.Name)
-		fmt.Println("URL:           ", getDatabaseUrl(config, &db))
+		fmt.Println("URL:           ", getDatabaseUrl(config, &db, false))
 		fmt.Println("ID:            ", db.ID)
 		fmt.Println("Locations:     ", strings.Join(regions, ", "))
 		fmt.Println()

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -60,8 +60,8 @@ func extractPrimary(instances []turso.Instance) (primary *turso.Instance, others
 	return primary, result
 }
 
-func getDatabaseUrl(settings *settings.Settings, db *turso.Database) string {
-	return getUrl(settings, db, nil, "libsql", false)
+func getDatabaseUrl(settings *settings.Settings, db *turso.Database, password bool) string {
+	return getUrl(settings, db, nil, "libsql", password)
 }
 
 func getInstanceUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance) string {


### PR DESCRIPTION
This adds a '--basic-auth' option that can be used with `turso db show --url` command to get the basic authentication credentials as part of the URL, which got dropped in recent cleanup.