### PR TITLE
Improve db inspect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 )
 
 require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -17,6 +17,7 @@ var showInstanceUrlFlag string
 var passwordFlag string
 var yesFlag bool
 var instanceFlag string
+var verboseFlag bool
 
 func getRegionIds(client *turso.Client) []string {
 	settings, err := settings.ReadSettings()

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -7,12 +7,31 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/chiselstrike/iku-turso-cli/internal/settings"
+	"github.com/dustin/go-humanize"
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	dbCmd.AddCommand(dbInspectCmd)
+	dbInspectCmd.Flags().BoolVar(&verboseFlag, "verbose", false, "Show detailed information")
+}
+
+type InspectInfo struct {
+	SizeTables  uint64
+	SizeIndexes uint64
+}
+
+func (curr *InspectInfo) Accumulate(n *InspectInfo) {
+	curr.SizeTables += n.SizeTables
+	curr.SizeIndexes += n.SizeIndexes
+}
+
+func (curr *InspectInfo) show() {
+	tables := humanize.Bytes(curr.SizeTables)
+	indexes := humanize.Bytes(curr.SizeIndexes)
+	fmt.Printf("Total space used for tables: %s\nTotal space used for indexes: %s\n", tables, indexes)
 }
 
 var dbInspectCmd = &cobra.Command{
@@ -27,58 +46,137 @@ var dbInspectCmd = &cobra.Command{
 			return fmt.Errorf("please specify a database name")
 		}
 		cmd.SilenceUsage = true
-		_, dbUrl, _, err := getDatabaseURL(name)
+
+		client := createTursoClient()
+		db, err := getDatabase(client, name)
 		if err != nil {
 			return err
 		}
-		return inspect(dbUrl)
+
+		config, err := settings.ReadSettings()
+		if err != nil {
+			return err
+		}
+
+		instances, err := client.Instances.List(db.Name)
+		if err != nil {
+			return err
+		}
+
+		inspectRet := InspectInfo{}
+		for _, instance := range instances {
+			url := getInstanceHttpUrl(config, &db, &instance)
+			ret, err := inspect(url, instance.Region, verboseFlag)
+			if err != nil {
+				return err
+			}
+			inspectRet.Accumulate(ret)
+		}
+		inspectRet.show()
+		return nil
 	},
 }
 
-func inspect(url string) error {
-	stmt := "select * from dbstat"
+func inspect(url string, location string, detailed bool) (*InspectInfo, error) {
+	inspectRet := InspectInfo{}
+
+	stmt := `select name, pgsize from dbstat where
+	name not like 'sqlite_%'
+        and name != '_litestream_seq'
+        and name != '_litestream_lock'
+        and name != 'libsql_wasm_func_table'
+	order by pgsize desc, name asc`
 	resp, err := doQuery(url, stmt)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	typeStmt := `select name, type from sqlite_schema where
+	name not like 'sqlite_%'
+        and name != '_litestream_seq'
+        and name != '_litestream_lock'
+        and name != 'libsql_wasm_func_table'`
+	respType, err := doQuery(url, typeStmt)
+	if err != nil {
+		return nil, err
+	}
+
 	defer resp.Body.Close()
+	defer respType.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error: %s", string(body))
+		return nil, fmt.Errorf("error: %s", string(body))
+	}
+
+	bodyType, err := io.ReadAll(respType.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if respType.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error: %s", string(body))
 	}
 
 	var results []QueryResult
 	if err := json.Unmarshal(body, &results); err != nil {
-		return err
+		return nil, err
 	}
+
+	var typeResults []QueryResult
+	if err := json.Unmarshal(bodyType, &typeResults); err != nil {
+		return nil, err
+	}
+
+	typeMap := make(map[string]string)
+	for _, result := range typeResults {
+		if result.Results != nil {
+			for _, row := range result.Results.Rows {
+				typeMap[row[0].(string)] = row[1].(string)
+			}
+		}
+	}
+
 	errs := []string{}
 	for _, result := range results {
 		if result.Error != nil {
 			errs = append(errs, result.Error.Message)
 		}
 		if result.Results != nil {
-			sizes := map[string]float64{}
-			for _, row := range result.Results.Rows {
-				name := row[0].(string)
-				size := row[9].(float64)
-				sizes[name] += size
-			}
 			columns := make([]interface{}, 0)
-			columns = append(columns, "TABLE/INDEX")
+			columns = append(columns, "TYPE")
+			columns = append(columns, "NAME")
 			columns = append(columns, "SIZE (KB)")
 			tbl := table.New(columns...)
-			for name, size := range sizes {
-				tbl.AddRow(name, size/1024.0)
+
+			for _, row := range result.Results.Rows {
+				type_ := "?"
+				name := row[0].(string)
+				if t, ok := typeMap[name]; ok {
+					type_ = t
+				}
+				size := uint64(row[1].(float64))
+				if type_ == "index" {
+					inspectRet.SizeIndexes += size
+				} else {
+					inspectRet.SizeTables += size
+				}
+				tbl.AddRow(type_, name, size/1024.0)
 			}
-			tbl.Print()
+			if detailed {
+				fmt.Printf("For location: %s\n", location)
+				tbl.Print()
+				fmt.Println()
+			}
 		}
 	}
 	if len(errs) > 0 {
-		return &SqlError{(strings.Join(errs, "; "))}
+		return nil, &SqlError{(strings.Join(errs, "; "))}
 	}
 
-	return nil
+	return &inspectRet, nil
 }


### PR DESCRIPTION
Show by-table only when --verbose is used. However in that case:
* differentiate between tables and indexes
* sort by size, then by name
* hide internal tables

Without the flag, only show the grand total, including all locations

Fixes #275