### PR TITLE
Fix createTursoClient() error handling

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -86,7 +86,11 @@ func isJwtTokenValid(token string) bool {
 	if len(token) == 0 {
 		return false
 	}
-	resp, err := createTursoClient().Get("/v2/validate/token", nil)
+	client, err := createTursoClient()
+	if err != nil {
+		return false
+	}
+	resp, err := client.Get("/v2/validate/token", nil)
 	return err == nil && resp.StatusCode == http.StatusOK
 }
 
@@ -179,7 +183,11 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 	}
 
 	firstTime := settings.RegisterUse("auth_login")
-	dbs, err := getDatabases(createTursoClient())
+	client, err := createTursoClient()
+	if err != nil {
+		return err
+	}
+	dbs, err := getDatabases(client)
 	if firstTime && err == nil && len(dbs) == 0 {
 		fmt.Printf("✏️  We are so happy you are here! Now that you are authenticated, it is time to create a database:\n\t%s\n", turso.Emph("turso db create"))
 	}

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -100,8 +100,12 @@ func getDatabases(client *turso.Client) ([]turso.Database, error) {
 }
 
 func completeInstanceName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := createTursoClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 	if len(args) == 1 {
-		return getInstanceNames(createTursoClient(), args[0]), cobra.ShellCompDirectiveNoFileComp
+		return getInstanceNames(client, args[0]), cobra.ShellCompDirectiveNoFileComp
 	}
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -37,7 +37,10 @@ var createCmd = &cobra.Command{
 		} else {
 			name = args[0]
 		}
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		region := locationFlag
 		if region != "" && !isValidRegion(client, region) {
 			return fmt.Errorf("location '%s' is not a valid one", region)

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -22,7 +22,10 @@ var destroyCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		name := args[0]
 		if instanceFlag != "" {
 			return destroyDatabaseInstance(client, name, instanceFlag)

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,10 @@ var dbGenerateTokenCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		name := args[0]
 
 		if _, err := getDatabase(client, name); err != nil {

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -47,7 +47,10 @@ var dbInspectCmd = &cobra.Command{
 		}
 		cmd.SilenceUsage = true
 
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		db, err := getDatabase(client, name)
 		if err != nil {
 			return err

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -20,7 +20,10 @@ var dbInvalidateTokensCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		name := args[0]
 
 		if _, err := getDatabase(client, name); err != nil {

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -20,7 +20,11 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		databases, err := getDatabases(createTursoClient())
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
+		databases, err := getDatabases(client)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -23,7 +23,10 @@ var regionsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		regions, err := turso.GetRegions(client)
 		if err != nil {
 			return err

--- a/internal/cmd/db_passwd.go
+++ b/internal/cmd/db_passwd.go
@@ -25,7 +25,10 @@ var changePasswordCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		db, err := getDatabase(client, args[0])
 		if err != nil {
 			return err
@@ -50,7 +53,11 @@ var changePasswordCmd = &cobra.Command{
 
 		bar := startLoadingBar("Changing password...")
 		defer bar.Stop()
-		err = createTursoClient().Databases.ChangePassword(args[0], newPassword)
+		client, err = createTursoClient()
+		if err != nil {
+			return err
+		}
+		err = client.Databases.ChangePassword(args[0], newPassword)
 		bar.Stop()
 		if err != nil {
 			return err

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -15,8 +15,12 @@ func init() {
 }
 
 func replicateArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := createTursoClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}
 	if len(args) == 1 {
-		return getRegionIds(createTursoClient()), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		return getRegionIds(client), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
 	return dbNameArg(cmd, args, toComplete)
 }
@@ -40,7 +44,10 @@ var replicateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		if !isValidRegion(client, region) {
 			return fmt.Errorf("invalid location ID. Run %s to see a list of valid location IDs", turso.Emph("turso db locations"))
 		}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -113,7 +113,10 @@ func getDatabaseURL(name string) (dbName, dbUrl string, libsqlUrl string, err er
 	dbName = name
 	_, err = url.ParseRequestURI(dbUrl)
 	if err != nil {
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return "", "", "", err
+		}
 		db, err := getDatabase(client, name)
 		if err != nil {
 			return "", "", "", err
@@ -124,7 +127,11 @@ func getDatabaseURL(name string) (dbName, dbUrl string, libsqlUrl string, err er
 
 	if strings.HasPrefix(dbUrl, "libsql://") {
 		libsqlUrl = dbUrl
-		dbs, err := getDatabases(createTursoClient())
+		client, err := createTursoClient()
+		if err != nil {
+			return "", "", "", err
+		}
+		dbs, err := getDatabases(client)
 		if err != nil {
 			return "", "", "", err
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -30,7 +30,10 @@ var showCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		db, err := getDatabase(client, args[0])
 		if err != nil {
 			return err

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -19,7 +19,10 @@ var dbUpdateCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client := createTursoClient()
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
 		name := args[0]
 
 		if _, err := getDatabase(client, name); err != nil {

--- a/internal/cmd/location_flag.go
+++ b/internal/cmd/location_flag.go
@@ -7,6 +7,10 @@ var locationFlag string
 func addLocationFlag(cmd *cobra.Command, desc string) {
 	cmd.Flags().StringVar(&locationFlag, "location", "", desc)
 	cmd.RegisterFlagCompletionFunc("location", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return getRegionIds(createTursoClient()), cobra.ShellCompDirectiveNoFileComp
+		client, err := createTursoClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return getRegionIds(client), cobra.ShellCompDirectiveNoFileComp
 	})
 }

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"github.com/spf13/cobra"
 	"log"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/briandowns/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
@@ -17,13 +18,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func createTursoClient() *turso.Client {
+func createTursoClient() (*turso.Client, error) {
 	token, err := getAccessToken()
 	if err != nil {
-		log.Fatal(fmt.Errorf("error creating Turso client: %w", err))
+		return nil, err
 	}
-
-	return tursoClient(&token)
+	return tursoClient(&token), nil
 }
 
 func createUnauthenticatedTursoClient() *turso.Client {
@@ -251,8 +251,12 @@ func promptConfirmation(prompt string) (bool, error) {
 }
 
 func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := createTursoClient()
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
 	if len(args) == 0 {
-		return getDatabaseNames(createTursoClient()), cobra.ShellCompDirectiveNoFileComp
+		return getDatabaseNames(client), cobra.ShellCompDirectiveNoFileComp
 	}
 	return []string{}, cobra.ShellCompDirectiveNoFileComp
 }


### PR DESCRIPTION
Propagate the error back to the callers so that we print out the actual error to the user when not logged in, for example.

Before:

2023/03/28 13:19:22 error creating Turso client: user not logged in, please use turso auth login

After:

Error: user not logged in, please use turso auth login