### PR TITLE
Switch to humanize.IBytes()

### DIFF
--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
@@ -65,7 +66,7 @@ var accountShowCmd = &cobra.Command{
 		columnFmt := color.New(color.FgBlue, color.Bold).SprintfFunc()
 		tbl.WithFirstColumnFormatter(columnFmt)
 
-		tbl.AddRow("storage", inspectRet.PrintTotal(), "8GB")
+		tbl.AddRow("storage", inspectRet.PrintTotal(), humanize.IBytes(8*1024*1024*1024))
 		tbl.AddRow("databases", numDatabases, "3")
 		tbl.AddRow("locations", numLocations, "3")
 		tbl.Print()

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -29,12 +29,12 @@ func (curr *InspectInfo) Accumulate(n *InspectInfo) {
 }
 
 func (curr *InspectInfo) PrintTotal() string {
-	return humanize.Bytes(curr.SizeTables + curr.SizeIndexes)
+	return humanize.IBytes(curr.SizeTables + curr.SizeIndexes)
 }
 
 func (curr *InspectInfo) show() {
-	tables := humanize.Bytes(curr.SizeTables)
-	indexes := humanize.Bytes(curr.SizeIndexes)
+	tables := humanize.IBytes(curr.SizeTables)
+	indexes := humanize.IBytes(curr.SizeIndexes)
 	fmt.Printf("Total space used for tables: %s\nTotal space used for indexes: %s\n", tables, indexes)
 }
 


### PR DESCRIPTION
Use humanize.IBytes() API because it shows "8 * 1024 * 1024" as "8 GiB" instead of "8.6 GB" as humanize.Bytes() does.