### PR TITLE
add sqld version on dev cmd

### DIFF
--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -16,6 +16,7 @@ func init() {
 	rootCmd.AddCommand(devCmd)
 	addDevPortFlag(devCmd)
 	addDevFileFlag(devCmd)
+	getSqldVersion(devCmd)
 }
 
 var devCmd = &cobra.Command{
@@ -26,6 +27,12 @@ var devCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
+
+		versionFlag, _ := cmd.Flags().GetBool("version")
+		if versionFlag {
+			sqldVersion()
+			return nil
+		}
 
 		tempDir, err := os.MkdirTemp("", "*tursodev")
 		if err != nil {
@@ -44,6 +51,9 @@ var devCmd = &cobra.Command{
 				return fmt.Errorf("Error creating link to file: %w", err)
 			}
 		}
+
+		fmt.Printf("Using sqld version: ")
+		sqldVersion()
 
 		addr := fmt.Sprintf("0.0.0.0:%d", devPort)
 		conn := fmt.Sprintf("http://127.0.0.1:%d", devPort)

--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -16,7 +16,7 @@ func init() {
 	rootCmd.AddCommand(devCmd)
 	addDevPortFlag(devCmd)
 	addDevFileFlag(devCmd)
-	getSqldVersion(devCmd)
+	addDevSqldVersionFlag(devCmd)
 }
 
 var devCmd = &cobra.Command{
@@ -28,9 +28,12 @@ var devCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		versionFlag, _ := cmd.Flags().GetBool("version")
-		if versionFlag {
-			sqldVersion()
+		if sqldVersion {
+			version, err := getSqldVersion()
+			if err != nil {
+				return err
+			}
+			fmt.Println(version)
 			return nil
 		}
 
@@ -51,9 +54,6 @@ var devCmd = &cobra.Command{
 				return fmt.Errorf("Error creating link to file: %w", err)
 			}
 		}
-
-		fmt.Printf("Using sqld version: ")
-		sqldVersion()
 
 		addr := fmt.Sprintf("0.0.0.0:%d", devPort)
 		conn := fmt.Sprintf("http://127.0.0.1:%d", devPort)

--- a/internal/cmd/dev_sqld_version.go
+++ b/internal/cmd/dev_sqld_version.go
@@ -8,17 +8,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func getSqldVersion(cmd *cobra.Command) {
-	cmd.Flags().BoolP("version", "v", false, "sqld version")
+var sqldVersion bool
+
+func addDevSqldVersionFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&sqldVersion, "version", "v", false, "sqld version")
 }
 
-func sqldVersion() {
+func getSqldVersion() (string, error) {
 	sqld := exec.Command("sqld", "--version")
 	sqld.Env = append(os.Environ(), "RUST_LOG=error")
 	version, err := sqld.Output()
 	if err != nil {
 		fmt.Println("Error running sqld --version:", err)
-		return
+		return "", err
 	}
-	fmt.Printf("%s\n", version)
+	return string(version), nil
 }

--- a/internal/cmd/dev_sqld_version.go
+++ b/internal/cmd/dev_sqld_version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func getSqldVersion(cmd *cobra.Command) {
+	cmd.Flags().BoolP("version", "v", false, "sqld version")
+}
+
+func sqldVersion() {
+	sqld := exec.Command("sqld", "--version")
+	sqld.Env = append(os.Environ(), "RUST_LOG=error")
+	version, err := sqld.Output()
+	if err != nil {
+		fmt.Println("Error running sqld --version:", err)
+		return
+	}
+	fmt.Printf("%s\n", version)
+}

--- a/internal/cmd/dev_sqld_version.go
+++ b/internal/cmd/dev_sqld_version.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -19,7 +18,6 @@ func getSqldVersion() (string, error) {
 	sqld.Env = append(os.Environ(), "RUST_LOG=error")
 	version, err := sqld.Output()
 	if err != nil {
-		fmt.Println("Error running sqld --version:", err)
 		return "", err
 	}
 	return string(version), nil


### PR DESCRIPTION
For #578 
Have added a flag for getting the `sqld` version from the `dev` command. 
It can be used as `turso dev --version`, also the `dev` command will print the sqld `version` in the prompt amongst the other details.

```bash
$ ./turso dev --version
sqld sqld 0.17.1 (ac41bce6 2023-07-27)

$ ./turso dev 
Using sqld version:sqld sqld 0.17.1 (ac41bce6 2023-07-27)

sqld listening on port 8080.
Use the following URL to configure your libSQL client SDK for local development:

    http://127.0.0.1:8080

No auth token is required when sqld is running locally.

This server is using an ephemeral database. Changes will be lost when this server stops.
If you want to persist changes, use --db-file to specify a SQLite database file instead.
```

Is there any specific way this is to be implemented? If am I wrong in this approach, please let me know, I am happy to work on it.

Some obvious things I would like to know more about:
- Parsing only the version number as `0.17.1`?
- Formatting of the output in a particular way?

Thank you