### PR TITLE
fix: restrict selectable plans

### DIFF
--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -119,14 +119,33 @@ var planSelectCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to get plans: %w", err)
 		}
-
-		selected, err := promptPlanSelection(plans, current)
+		selectabledPlans, err := getSelectabledPlans(plans)
+		if err != nil {
+			return err
+		}
+		selected, err := promptPlanSelection(selectabledPlans, current)
 		if err != nil {
 			return err
 		}
 
 		return changePlan(client, plans, current, hasPaymentMethod, selected)
 	},
+}
+
+func getSelectabledPlans(plans []turso.Plan) ([]turso.Plan, error) {
+	settings, err := settings.ReadSettings()
+	if err != nil {
+		return plans, err
+	}
+
+	org := settings.Organization()
+	var plansToSelect []turso.Plan
+	for _, plan := range plans {
+		if plan.Name != "starter" || org == "" {
+			plansToSelect = append(plansToSelect, plan)
+		}
+	}
+	return plansToSelect, nil
 }
 
 var planUpgradeCmd = &cobra.Command{


### PR DESCRIPTION
in my personal org
<img width="417" alt="Screen Shot 2023-07-28 at 3 55 59 PM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/2fa0c8c5-17e2-417d-bcea-676336dcbce0">


In my team org

<img width="400" alt="Screen Shot 2023-07-28 at 3 56 17 PM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/d905e1f2-b02c-4ce7-8056-f2c12c217cee">
