### PR TITLE
Use TURSO_CONFIG_FOLDER env var to change the configuration folder

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -30,6 +30,8 @@ func ReadSettings() (*Settings, error) {
 	settings = &Settings{}
 
 	configPath := configdir.LocalConfig("turso")
+	viper.BindEnv("config-path", "TURSO_CONFIG_FOLDER")
+
 	configPathFlag := viper.GetString("config-path")
 	if len(configPathFlag) > 0 {
 		configPath = configPathFlag


### PR DESCRIPTION
This allows us to do something like:
```
export TURSO_CONFIG_FOLDER=~/.turso/prod
```
To switch between local and prod configs and avoid the constant `turso auth logout && turso auth login` while developing/operating the platform.