### PR TITLE
add message to alert upgrades on personal orgs

### DIFF
--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -204,6 +204,18 @@ func ChangePlan(client *turso.Client, plans []turso.Plan, current string, hasPay
 		printPricingInfoDisclaimer()
 	}
 
+	settings, err := settings.ReadSettings()
+	if err != nil {
+		return err
+	}
+
+	org := settings.Organization()
+	if change == "upgrading" && org == "" {
+		fmt.Println("You're currently using your personal organization.")
+		fmt.Println("In personal organizations, you cannot invite members to collaborate.")
+		fmt.Printf("If you want instead to upgrade to scaler plan, you can create an organization with %s.\n", internal.Emph("turso org create"))
+	}
+
 	if ok, _ := promptConfirmation("Do you want to continue?"); !ok {
 		fmt.Printf("Plan change cancelled. You're still on %s.\n", internal.Emph(current))
 		return nil

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -213,7 +213,7 @@ func ChangePlan(client *turso.Client, plans []turso.Plan, current string, hasPay
 	if change == "upgrading" && org == "" {
 		fmt.Println("You're currently using your personal organization.")
 		fmt.Println("In personal organizations, you cannot invite members to collaborate.")
-		fmt.Printf("If you want instead to upgrade to scaler plan, you can create an organization with %s.\n", internal.Emph("turso org create"))
+		fmt.Printf("If you want instead to upgrade aa team org to the scaler plan, you can create an organization with %s.\n", internal.Emph("turso org create"))
 	}
 
 	if ok, _ := promptConfirmation("Do you want to continue?"); !ok {


### PR DESCRIPTION
This is an attempt to alert users that they are upgrading personal orgs and try to nudge them into creating team orgs, lots of users are updating their personal accounts by mistake, and this is generating manual work to fix it.