### PR TITLE
Add commands for managing groups under preview build flag

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -16,7 +16,6 @@ var showUrlFlag bool
 var showHttpUrlFlag bool
 var showInstanceUrlsFlag bool
 var showInstanceUrlFlag string
-var yesFlag bool
 
 func getInstanceNames(client *turso.Client, dbName string) []string {
 	instances, err := client.Instances.List(dbName)

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -31,7 +31,7 @@ var listCmd = &cobra.Command{
 		var data [][]string
 		var helps []string
 		for _, database := range databases {
-			row := []string{database.Name, getDatabaseRegions(database), getDatabaseUrl(&database)}
+			row := []string{database.Name, getDatabaseLocations(database), getDatabaseUrl(&database)}
 			if len(database.Regions) == 0 {
 				help := fmt.Sprintf("🛠 Run %s to finish your database creation!", internal.Emph("turso db replicate "+database.Name))
 				helps = append(helps, help)

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -75,7 +75,7 @@ var groupsCreateCmd = &cobra.Command{
 		}
 
 		start := time.Now()
-		description := fmt.Sprintf("Creating group %s in %s", internal.Emph(name), internal.Emph(location))
+		description := fmt.Sprintf("Creating group %s at %s...", internal.Emph(name), internal.Emph(location))
 		spinner := prompt.Spinner(description)
 		defer spinner.Stop()
 
@@ -85,7 +85,7 @@ var groupsCreateCmd = &cobra.Command{
 
 		spinner.Stop()
 		elapsed := time.Since(start)
-		fmt.Printf("Created group %s in %s in %d seconds.\n\n", internal.Emph(name), internal.Emph(location), int(elapsed.Seconds()))
+		fmt.Printf("Created group %s at %s in %d seconds.\n", internal.Emph(name), internal.Emph(location), int(elapsed.Seconds()))
 		return nil
 	},
 }

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -1,0 +1,148 @@
+//go:build preview
+// +build preview
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/chiselstrike/iku-turso-cli/internal"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/spf13/cobra"
+)
+
+var groupCmd = &cobra.Command{
+	Use:   "group",
+	Short: "Manage your database groups",
+}
+
+func init() {
+	rootCmd.AddCommand(groupCmd)
+	groupCmd.AddCommand(groupsListCmd)
+	groupCmd.AddCommand(groupsCreateCmd)
+	addLocationFlag(groupsCreateCmd, "Create the group primary in the specified location")
+	groupCmd.AddCommand(groupsDestroyCmd)
+	addYesFlag(groupsDestroyCmd, "Confirms the destruction of the group, with all its locations and databases.")
+}
+
+var groupsListCmd = &cobra.Command{
+	Use:               "list",
+	Short:             "List databases groups",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		client, err := createTursoClientFromAccessToken(true)
+		if err != nil {
+			return err
+		}
+
+		groups, err := client.Groups.List()
+		if err != nil {
+			return err
+		}
+
+		printTable([]string{"Name", "Locations"}, groupsTable(groups))
+		return nil
+	},
+}
+
+var groupsCreateCmd = &cobra.Command{
+	Use:               "create [group_name]",
+	Short:             "Create a database group",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		client, err := createTursoClientFromAccessToken(true)
+		if err != nil {
+			return err
+		}
+
+		name := args[0]
+		if err := turso.CheckName(name); err != nil {
+			return fmt.Errorf("invalid group name: %w", err)
+		}
+
+		location := locationFlag
+		if location == "" {
+			location, _ = closestLocation(client)
+		}
+		if !isValidLocation(client, location) {
+			return fmt.Errorf("location '%s' is not a valid one", location)
+		}
+
+		start := time.Now()
+		description := fmt.Sprintf("Creating group %s in %s", internal.Emph(name), internal.Emph(location))
+		spinner := prompt.Spinner(description)
+		defer spinner.Stop()
+
+		if err := client.Groups.Create(name, location); err != nil {
+			return err
+		}
+
+		spinner.Stop()
+		elapsed := time.Since(start)
+		fmt.Printf("Created group %s in %s in %d seconds.\n\n", internal.Emph(name), internal.Emph(location), int(elapsed.Seconds()))
+		return nil
+	},
+}
+
+var groupsDestroyCmd = &cobra.Command{
+	Use:               "destroy [group_name]",
+	Short:             "Destroy a database group",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		client, err := createTursoClientFromAccessToken(true)
+		if err != nil {
+			return err
+		}
+
+		name := args[0]
+		if yesFlag {
+			return destroyGroup(client, name)
+		}
+
+		fmt.Printf("Group %s, all its replicas and databases will be destroyed.\n", internal.Emph(name))
+
+		ok, err := promptConfirmation("Are you sure you want to do this?")
+		if err != nil {
+			return fmt.Errorf("could not get prompt confirmed by user: %w", err)
+		}
+
+		if !ok {
+			fmt.Println("Group destruction avoided.")
+			return nil
+		}
+
+		return destroyGroup(client, name)
+	},
+}
+
+func destroyGroup(client *turso.Client, name string) error {
+	start := time.Now()
+	s := prompt.Spinner(fmt.Sprintf("Destroying group %s... ", internal.Emph(name)))
+	defer s.Stop()
+
+	if err := client.Groups.Delete(name); err != nil {
+		return err
+	}
+	s.Stop()
+	elapsed := time.Since(start)
+
+	fmt.Printf("Destroyed group %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
+	return nil
+}
+
+func groupsTable(groups []turso.Group) [][]string {
+	var data [][]string
+	for _, group := range groups {
+		row := []string{group.Name, formatLocations(group.Locations, group.Primary)}
+		data = append(data, row)
+	}
+	return data
+}

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -8,3 +8,8 @@ func addGroupFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&groupFlag, "group", "", "create the database in the specified group")
 	cmd.Flags().MarkHidden("group")
 }
+
+func addPersistentGroupFlag(cmd *cobra.Command, description string) {
+	cmd.PersistentFlags().StringVarP(&groupFlag, "group", "g", "", description)
+	cmd.Flags().MarkHidden("group")
+}

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -74,21 +74,21 @@ var groupLocationAddCmd = &cobra.Command{
 		}
 
 		start := time.Now()
-		spinner := prompt.StoppedSpinner("")
+		spinner := prompt.Spinner("")
 		defer spinner.Stop()
 
 		for _, location := range args {
-			description := fmt.Sprintf("Replicating group %s to %s", internal.Emph(groupFlag), internal.Emph(location))
+			description := fmt.Sprintf("Replicating group %s to %s...", internal.Emph(groupFlag), internal.Emph(location))
 			spinner.Text(description)
 
 			if err := client.Groups.AddLocation(groupFlag, location); err != nil {
-				return err
+				return fmt.Errorf("failed to replicate group %s to %s: %w", groupFlag, location, err)
 			}
 		}
 
 		spinner.Stop()
 		elapsed := time.Since(start)
-		fmt.Printf("Group %s replicated to %d locations in %d seconds.\n\n", internal.Emph(groupFlag), len(args), int(elapsed.Seconds()))
+		fmt.Printf("Group %s replicated to %d locations in %d seconds.\n", internal.Emph(groupFlag), len(args), int(elapsed.Seconds()))
 		return nil
 	},
 }
@@ -124,21 +124,21 @@ var groupsLocationsRmCmd = &cobra.Command{
 		}
 
 		start := time.Now()
-		spinner := prompt.StoppedSpinner("")
+		spinner := prompt.Spinner("")
 		defer spinner.Stop()
 
 		for _, location := range args {
-			description := fmt.Sprintf("Replicating group %s to %s", internal.Emph(groupFlag), internal.Emph(location))
+			description := fmt.Sprintf("Removing group %s from %s...", internal.Emph(groupFlag), internal.Emph(location))
 			spinner.Text(description)
 
 			if err := client.Groups.RemoveLocation(groupFlag, location); err != nil {
-				return err
+				return fmt.Errorf("failed to remove group %s from %s: %w", groupFlag, location, err)
 			}
 		}
 
 		spinner.Stop()
 		elapsed := time.Since(start)
-		fmt.Printf("Group %s removed from %d locations in %d seconds.\n\n", internal.Emph(groupFlag), len(args), int(elapsed.Seconds()))
+		fmt.Printf("Group %s removed from %d locations in %d seconds.\n", internal.Emph(groupFlag), len(args), int(elapsed.Seconds()))
 		return nil
 	},
 }

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -1,0 +1,144 @@
+//go:build preview
+// +build preview
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/chiselstrike/iku-turso-cli/internal"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+var groupLocationsCmd = &cobra.Command{
+	Use:   "locations",
+	Short: "Manage your database group locations",
+}
+
+func init() {
+	groupCmd.AddCommand(groupLocationsCmd)
+	groupLocationsCmd.AddCommand(groupLocationsListCmd)
+	addPersistentGroupFlag(groupLocationsCmd, "Use the specified group as target for the operation")
+	groupLocationsCmd.AddCommand(groupLocationAddCmd)
+	groupLocationsCmd.AddCommand(groupsLocationsRmCmd)
+}
+
+var groupLocationsListCmd = &cobra.Command{
+	Use:               "list",
+	Short:             "List database group locations",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if groupFlag == "" {
+			return fmt.Errorf("the group flag is required")
+		}
+
+		cmd.SilenceUsage = true
+		client, err := createTursoClientFromAccessToken(true)
+		if err != nil {
+			return err
+		}
+
+		groups, err := client.Groups.Get(groupFlag)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(formatLocations(groups.Locations, groups.Primary))
+		return nil
+	},
+}
+
+var groupLocationAddCmd = &cobra.Command{
+	Use:               "add [...locations]",
+	Short:             "Add locations to a database group",
+	Args:              cobra.MinimumNArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if groupFlag == "" {
+			return fmt.Errorf("the group flag is required")
+		}
+
+		cmd.SilenceUsage = true
+		client, err := createTursoClientFromAccessToken(true)
+		if err != nil {
+			return err
+		}
+
+		for _, location := range args {
+			if !isValidLocation(client, location) {
+				return fmt.Errorf("location '%s' is not a valid one", location)
+			}
+		}
+
+		start := time.Now()
+		spinner := prompt.StoppedSpinner("")
+		defer spinner.Stop()
+
+		for _, location := range args {
+			description := fmt.Sprintf("Replicating group %s to %s", internal.Emph(groupFlag), internal.Emph(location))
+			spinner.Text(description)
+
+			if err := client.Groups.AddLocation(groupFlag, location); err != nil {
+				return err
+			}
+		}
+
+		spinner.Stop()
+		elapsed := time.Since(start)
+		fmt.Printf("Group %s replicated to %d locations in %d seconds.\n\n", internal.Emph(groupFlag), len(args), int(elapsed.Seconds()))
+		return nil
+	},
+}
+
+var groupsLocationsRmCmd = &cobra.Command{
+	Use:               "remove [...locations]",
+	Short:             "Remove locations from a database group",
+	Args:              cobra.MinimumNArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if groupFlag == "" {
+			return fmt.Errorf("the group flag is required")
+		}
+
+		cmd.SilenceUsage = true
+		client, err := createTursoClientFromAccessToken(true)
+		if err != nil {
+			return err
+		}
+
+		group, err := client.Groups.Get(groupFlag)
+		if err != nil {
+			return err
+		}
+
+		for _, location := range args {
+			if !isValidLocation(client, location) {
+				return fmt.Errorf("location '%s' is not a valid one", location)
+			}
+			if group.Primary == location {
+				return fmt.Errorf("cannot remove primary location '%s' from group '%s'", location, groupFlag)
+			}
+		}
+
+		start := time.Now()
+		spinner := prompt.StoppedSpinner("")
+		defer spinner.Stop()
+
+		for _, location := range args {
+			description := fmt.Sprintf("Replicating group %s to %s", internal.Emph(groupFlag), internal.Emph(location))
+			spinner.Text(description)
+
+			if err := client.Groups.RemoveLocation(groupFlag, location); err != nil {
+				return err
+			}
+		}
+
+		spinner.Stop()
+		elapsed := time.Since(start)
+		fmt.Printf("Group %s removed from %d locations in %d seconds.\n\n", internal.Emph(groupFlag), len(args), int(elapsed.Seconds()))
+		return nil
+	},
+}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -95,16 +95,20 @@ func getUrl(db *turso.Database, inst *turso.Instance, scheme string) string {
 	return fmt.Sprintf("%s://%s", scheme, host)
 }
 
-func getDatabaseRegions(db turso.Database) string {
-	regions := make([]string, 0, len(db.Regions))
-	for _, region := range db.Regions {
-		if region == db.PrimaryRegion {
-			region = fmt.Sprintf("%s (primary)", internal.Emph(region))
+func getDatabaseLocations(db turso.Database) string {
+	return formatLocations(db.Regions, db.PrimaryRegion)
+}
+
+func formatLocations(locations []string, primary string) string {
+	formatted := make([]string, 0, len(locations))
+	for _, location := range locations {
+		if location == primary {
+			location = fmt.Sprintf("%s (primary)", internal.Emph(location))
 		}
-		regions = append(regions, region)
+		formatted = append(formatted, location)
 	}
 
-	return strings.Join(regions, ", ")
+	return strings.Join(formatted, ", ")
 }
 
 func printTable(header []string, data [][]string) {

--- a/internal/cmd/yes_flag.go
+++ b/internal/cmd/yes_flag.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var yesFlag bool
+
+func addYesFlag(cmd *cobra.Command, desc string) {
+	cmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, desc)
+}

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -1,0 +1,99 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/chiselstrike/iku-turso-cli/internal"
+)
+
+type GroupsClient client
+
+type Group struct {
+	Name      string   `json:"name"`
+	Locations []string `json:"locations"`
+	Primary   string   `json:"primary"`
+}
+
+func (d *GroupsClient) List() ([]Group, error) {
+	r, err := d.client.Get(d.URL(""), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get groups: %s", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get database groups: received status code %s", r.Status)
+	}
+
+	type ListResponse struct {
+		Groups []Group `json:"groups"`
+	}
+	resp, err := unmarshal[ListResponse](r)
+	return resp.Groups, err
+}
+
+func (d *GroupsClient) Delete(group string) error {
+	url := d.URL("/" + group)
+	r, err := d.client.Delete(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete group: %s", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("group %s not found. List known databases using %s", internal.Emph(group), internal.Emph("turso group list"))
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete group: received status code %s", r.Status)
+	}
+
+	return nil
+}
+
+func (d *GroupsClient) Create(name, location string) error {
+	type Body struct{ Name, Location string }
+	body, err := marshal(Body{name, location})
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	res, err := d.client.Post(d.URL(""), body)
+	if err != nil {
+		return fmt.Errorf("failed to create group: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("group name '%s' is not available", name)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+func (d *GroupsClient) URL(suffix string) string {
+	prefix := "/v1"
+	if d.client.Org != "" {
+		prefix = "/v1/organizations/" + d.client.Org
+	}
+	return prefix + "/groups" + suffix
+}

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -35,6 +35,7 @@ type Client struct {
 	Plans         *PlansClient
 	Subscriptions *SubscriptionClient
 	Billing       *BillingClient
+	Groups        *GroupsClient
 }
 
 // Client struct that will be aliases by all other clients
@@ -57,6 +58,7 @@ func New(base *url.URL, token string, cliVersion string, org string) *Client {
 	c.Plans = (*PlansClient)(c.base)
 	c.Subscriptions = (*SubscriptionClient)(c.base)
 	c.Billing = (*BillingClient)(c.base)
+	c.Groups = (*GroupsClient)(c.base)
 	return c
 }
 


### PR DESCRIPTION
Adds the following command:
``` shell
> turso group
Manage your database groups

Usage:
  turso group [command]

Available Commands:
  create      Create a database group
  destroy     Destroy a database group
  list        List databases groups
  locations   Manage your database group locations
  ```

With the extra subcommand under `turso group locations`:
```shell
> turso group locations
Manage your database group locations

Usage:
  turso group locations [command]

Available Commands:
  add         Add locations to a database group
  list        List database group locations
  remove      Remove locations from a database group

Flags:
  -g, --group string   Use the specified group as target for the operation
```

---

The later commands work in a way that is different from current commands from the CLI.
The group in `turso group locations` subcommands must be specified with the `-g` flag.
This allows all arguments to be locations, and IMO, fits better with the cobra model.
This is something that we can change if it generates friction.

---

Example of usage:
```shell
> turso group create bar --location iad
Created group bar at iad in 6 seconds.
> turso group list
NAME     LOCATIONS     
foo      gru (primary)     
bar      iad (primary)     
> turso group locations add gru scl gig -g bar
Error: could not create group instance: maximum database count of 3 reached
> turso group locations add gru scl gig -g bar # after updating plans
Group bar replicated to 3 locations in 10 seconds.
> turso group list
NAME     LOCATIONS                    
foo      gru (primary)                    
bar      iad (primary), gru, scl, gig    
> turso group destroy bar -y
Destroyed group bar in 0 seconds.
> turso group list          
NAME     LOCATIONS     
foo      gru (primary)     
```