### PR TITLE
Remove preview build flag and hide turso group command

### DIFF
--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -1,6 +1,3 @@
-//go:build preview
-// +build preview
-
 package cmd
 
 import (
@@ -14,8 +11,9 @@ import (
 )
 
 var groupCmd = &cobra.Command{
-	Use:   "group",
-	Short: "Manage your database groups",
+	Use:    "group",
+	Short:  "Manage your database groups",
+	Hidden: true,
 }
 
 func init() {

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -11,5 +11,4 @@ func addGroupFlag(cmd *cobra.Command) {
 
 func addPersistentGroupFlag(cmd *cobra.Command, description string) {
 	cmd.PersistentFlags().StringVarP(&groupFlag, "group", "g", "", description)
-	cmd.Flags().MarkHidden("group")
 }

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -1,6 +1,3 @@
-//go:build preview
-// +build preview
-
 package cmd
 
 import (


### PR DESCRIPTION
This will make it always present, but hidden from end users. If users type "turso group" they still have access to autocomplete and help functions.