### PR TITLE
Get group as the first parameter and locations as flags on turso group locations cmds

### DIFF
--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -48,7 +48,7 @@ var groupsListCmd = &cobra.Command{
 }
 
 var groupsCreateCmd = &cobra.Command{
-	Use:               "create [group_name]",
+	Use:               "create [group]",
 	Short:             "Create a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
@@ -89,7 +89,7 @@ var groupsCreateCmd = &cobra.Command{
 }
 
 var groupsDestroyCmd = &cobra.Command{
-	Use:               "destroy [group_name]",
+	Use:               "destroy [group]",
 	Short:             "Destroy a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -91,6 +91,12 @@ var groupLocationAddCmd = &cobra.Command{
 
 		spinner.Stop()
 		elapsed := time.Since(start)
+
+		if len(locationsFlag) == 1 {
+			fmt.Printf("Group %s replicated to %s in %d seconds.\n", internal.Emph(group), internal.Emph(locationsFlag[0]), int(elapsed.Seconds()))
+			return nil
+		}
+
 		fmt.Printf("Group %s replicated to %d locations in %d seconds.\n", internal.Emph(group), len(locationsFlag), int(elapsed.Seconds()))
 		return nil
 	},
@@ -145,6 +151,12 @@ var groupsLocationsRmCmd = &cobra.Command{
 
 		spinner.Stop()
 		elapsed := time.Since(start)
+
+		if len(locationsFlag) == 1 {
+			fmt.Printf("Group %s removed from %s in %d seconds.\n", internal.Emph(groupName), internal.Emph(locationsFlag[0]), int(elapsed.Seconds()))
+			return nil
+		}
+
 		fmt.Printf("Group %s removed from %d locations in %d seconds.\n", internal.Emph(groupName), len(locationsFlag), int(elapsed.Seconds()))
 		return nil
 	},

--- a/internal/cmd/location_flag.go
+++ b/internal/cmd/location_flag.go
@@ -6,15 +6,23 @@ import (
 )
 
 var locationFlag string
+var locationsFlag []string
+
+func locationCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := createTursoClientFromAccessToken(false)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	locations, _ := locations(client)
+	return maps.Keys(locations), cobra.ShellCompDirectiveNoFileComp
+}
 
 func addLocationFlag(cmd *cobra.Command, desc string) {
 	cmd.Flags().StringVar(&locationFlag, "location", "", desc)
-	cmd.RegisterFlagCompletionFunc("location", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client, err := createTursoClientFromAccessToken(false)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		locations, _ := locations(client)
-		return maps.Keys(locations), cobra.ShellCompDirectiveNoFileComp
-	})
+	cmd.RegisterFlagCompletionFunc("location", locationCompletion)
+}
+
+func addLocationsFlag(cmd *cobra.Command, desc string) {
+	cmd.Flags().StringSliceVarP(&locationsFlag, "locations", "l", []string{}, desc)
+	cmd.RegisterFlagCompletionFunc("locations", locationCompletion)
 }

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -86,6 +86,10 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 
 func (t *Client) do(method, path string, body io.Reader) (*http.Response, error) {
 	req, err := t.newRequest(method, path, body)
+	var reqDump string
+	if flags.Debug() {
+		reqDump = dumpRequest(req)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -94,29 +98,34 @@ func (t *Client) do(method, path string, body io.Reader) (*http.Response, error)
 		return nil, err
 	}
 	if flags.Debug() {
-		dumpRequest(req)
-		dumpResponse(resp)
-		fmt.Println()
+		printDumps(reqDump, dumpResponse(resp))
 	}
 	return resp, nil
 }
 
-func dumpRequest(req *http.Request) {
-	dump, err := httputil.DumpRequestOut(req, true)
-	if err != nil {
-		fmt.Printf("Failed to dump the HTTP request, you can either remove the debug flag or ignore this error: %s", err.Error())
-		return
+func printDumps(req, resp string) {
+	if req != "" {
+		fmt.Println(req)
 	}
-	fmt.Println(string(dump))
+	if resp != "" {
+		fmt.Println(resp)
+	}
 }
 
-func dumpResponse(req *http.Response) {
+func dumpRequest(req *http.Request) string {
+	dump, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return ""
+	}
+	return string(dump)
+}
+
+func dumpResponse(req *http.Response) string {
 	dump, err := httputil.DumpResponse(req, true)
 	if err != nil {
-		fmt.Printf("Failed to dump the HTTP response, you can either remove the debug flag or ignore this error: %s", err.Error())
-		return
+		return ""
 	}
-	fmt.Println(string(dump))
+	return string(dump)
 }
 
 func (t *Client) Get(path string, body io.Reader) (*http.Response, error) {


### PR DESCRIPTION
Examples:

```sh
> turso group locations add foo -l scl,iad
Group foo replicated to 2 locations in 12 seconds.
> turso group locations list foo
gru (primary), scl, iad
> turso group locations remove foo -l scl,iad
Group foo removed from 2 locations in 5 seconds.
> turso group locations list foo
gru (primary)
```

