### PR TITLE
Get turso db locations (add|remove) parameters from CLI arguments

### DIFF
--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -48,7 +48,7 @@ var groupsListCmd = &cobra.Command{
 }
 
 var groupsCreateCmd = &cobra.Command{
-	Use:               "create [group_name]",
+	Use:               "create [group]",
 	Short:             "Create a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
@@ -89,7 +89,7 @@ var groupsCreateCmd = &cobra.Command{
 }
 
 var groupsDestroyCmd = &cobra.Command{
-	Use:               "destroy [group_name]",
+	Use:               "destroy [group]",
 	Short:             "Destroy a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -8,7 +8,3 @@ func addGroupFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&groupFlag, "group", "", "create the database in the specified group")
 	cmd.Flags().MarkHidden("group")
 }
-
-func addPersistentGroupFlag(cmd *cobra.Command, description string) {
-	cmd.PersistentFlags().StringVarP(&groupFlag, "group", "g", "", description)
-}

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 )
 
 var groupLocationsCmd = &cobra.Command{
@@ -52,7 +53,7 @@ var groupLocationAddCmd = &cobra.Command{
 	Use:               "add [group] [...locations]",
 	Short:             "Add locations to a database group",
 	Args:              cobra.MinimumNArgs(2),
-	ValidArgsFunction: noFilesArg,
+	ValidArgsFunction: locationsCmdsArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		group := args[0]
 		if group == "" {
@@ -102,7 +103,7 @@ var groupsLocationsRmCmd = &cobra.Command{
 	Use:               "remove [group] [...locations]",
 	Short:             "Remove locations from a database group",
 	Args:              cobra.MinimumNArgs(2),
-	ValidArgsFunction: noFilesArg,
+	ValidArgsFunction: locationsCmdsArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		groupName := args[0]
 		if groupName == "" {
@@ -154,4 +155,17 @@ var groupsLocationsRmCmd = &cobra.Command{
 		fmt.Printf("Group %s removed from %d locations in %d seconds.\n", internal.Emph(groupName), len(locations), int(elapsed.Seconds()))
 		return nil
 	},
+}
+
+func locationsCmdsArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := createTursoClientFromAccessToken(false)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}
+	if len(args) == 0 {
+		// TODO: add completion for group names
+		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}
+	locations, _ := locations(client)
+	return maps.Keys(locations), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }


### PR DESCRIPTION
Examples:

```sh
> turso group list
NAME     LOCATIONS     
foo      gru (primary)     
> turso group create bar 
Created group bar at gru in 8 seconds.
> turso group locations list bar
gru (primary)
> turso group locations add bar gig
Group bar replicated to gig in 4 seconds.
> turso group locations add bar iad scl
Group bar replicated to 2 locations in 12 seconds.
> turso group locations add bar gig gru
Group bar replicated to 2 locations in 0 seconds.
```

The last example hints to the user that the replications were successful, where they are actually no-ops.
It should be fixed in the next PRs.