### PR TITLE
Group autocomplete

### DIFF
--- a/internal/cmd/cache.go
+++ b/internal/cmd/cache.go
@@ -107,3 +107,7 @@ func getGroupsCache(org string) []turso.Group {
 	}
 	return data
 }
+
+func invalidateGroupsCache(org string) {
+	settings.InvalidateCache[[]turso.Group](orgKey(org, GROUP_CACHE_KEY))
+}

--- a/internal/cmd/cache.go
+++ b/internal/cmd/cache.go
@@ -83,3 +83,27 @@ func dbTokenCache(dbID string) string {
 	}
 	return token
 }
+
+const ORG_CACHE_KEY = "organizations"
+const GROUP_CACHE_KEY = "groups"
+const GROUP_CACHE_TTL_SECONDS = 30 * 60
+
+func orgKey(org, suffix string) string {
+	key := suffix
+	if org != "" {
+		key = ORG_CACHE_KEY + "." + org + "." + suffix
+	}
+	return key
+}
+
+func setGroupsCache(org string, groups []turso.Group) {
+	settings.SetCache(orgKey(org, GROUP_CACHE_KEY), GROUP_CACHE_TTL_SECONDS, groups)
+}
+
+func getGroupsCache(org string) []turso.Group {
+	data, err := settings.GetCache[[]turso.Group](orgKey(org, GROUP_CACHE_KEY))
+	if err != nil {
+		return nil
+	}
+	return data
+}

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -84,6 +84,7 @@ var groupsCreateCmd = &cobra.Command{
 		spinner.Stop()
 		elapsed := time.Since(start)
 		fmt.Printf("Created group %s at %s in %d seconds.\n", internal.Emph(name), internal.Emph(location), int(elapsed.Seconds()))
+		invalidateGroupsCache(client.Org)
 		return nil
 	},
 }
@@ -133,6 +134,7 @@ func destroyGroup(client *turso.Client, name string) error {
 	elapsed := time.Since(start)
 
 	fmt.Printf("Destroyed group %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
+	invalidateGroupsCache(client.Org)
 	return nil
 }
 

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -144,3 +144,41 @@ func groupsTable(groups []turso.Group) [][]string {
 	}
 	return data
 }
+
+func getGroups(client *turso.Client, fresh ...bool) ([]turso.Group, error) {
+	skipCache := len(fresh) > 0 && fresh[0]
+	if cached := getGroupsCache(client.Org); !skipCache && cached != nil {
+		return cached, nil
+	}
+	groups, err := client.Groups.List()
+	if err != nil {
+		return nil, err
+	}
+	setGroupsCache(client.Org, groups)
+	return groups, nil
+}
+
+func groupNames(client *turso.Client) ([]string, error) {
+	groups, err := getGroups(client)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(groups))
+	for _, group := range groups {
+		names = append(names, group.Name)
+	}
+	return names, nil
+}
+
+func getGroup(client *turso.Client, name string) (turso.Group, error) {
+	groups, err := getGroups(client)
+	if err != nil {
+		return turso.Group{}, err
+	}
+	for _, group := range groups {
+		if group.Name == name {
+			return group, nil
+		}
+	}
+	return turso.Group{}, fmt.Errorf("group %s was not found", name)
+}

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -37,7 +37,7 @@ var groupsListCmd = &cobra.Command{
 			return err
 		}
 
-		groups, err := client.Groups.List()
+		groups, err := getGroups(client, true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -7,4 +7,12 @@ var groupFlag string
 func addGroupFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&groupFlag, "group", "", "create the database in the specified group")
 	cmd.Flags().MarkHidden("group")
+	cmd.RegisterFlagCompletionFunc("group", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		client, err := createTursoClientFromAccessToken(false)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		groups, _ := groupNames(client)
+		return groups, cobra.ShellCompDirectiveNoFileComp
+	})
 }

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -53,7 +53,7 @@ var groupLocationAddCmd = &cobra.Command{
 	Use:               "add [group] [...locations]",
 	Short:             "Add locations to a database group",
 	Args:              cobra.MinimumNArgs(2),
-	ValidArgsFunction: locationsCmdsArgs,
+	ValidArgsFunction: locationsAddArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		group := args[0]
 		if group == "" {
@@ -105,7 +105,7 @@ var groupsLocationsRmCmd = &cobra.Command{
 	Use:               "remove [group] [...locations]",
 	Short:             "Remove locations from a database group",
 	Args:              cobra.MinimumNArgs(2),
-	ValidArgsFunction: locationsCmdsArgs,
+	ValidArgsFunction: locationsRmArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		groupName := args[0]
 		if groupName == "" {
@@ -161,7 +161,7 @@ var groupsLocationsRmCmd = &cobra.Command{
 	},
 }
 
-func locationsCmdsArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func locationsAddArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		return groupArgs(cmd, args, toComplete)
 	}
@@ -180,6 +180,30 @@ func locationsCmdsArgs(cmd *cobra.Command, args []string, toComplete string) ([]
 
 	group, _ := getGroup(client, args[0])
 	for _, location := range group.Locations {
+		delete(locations, location)
+	}
+
+	return maps.Keys(locations), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+func locationsRmArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return groupArgs(cmd, args, toComplete)
+	}
+
+	client, err := createTursoClientFromAccessToken(false)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}
+
+	group, _ := getGroup(client, args[0])
+	locations := make(map[string]bool, len(group.Locations))
+	for _, location := range group.Locations {
+		locations[location] = true
+	}
+
+	used := args[1:]
+	for _, location := range used {
 		delete(locations, location)
 	}
 

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -158,18 +158,36 @@ var groupsLocationsRmCmd = &cobra.Command{
 }
 
 func locationsCmdsArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return groupArgs(cmd, args, toComplete)
+	}
+
 	client, err := createTursoClientFromAccessToken(false)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
-	if len(args) == 0 {
-		// TODO: add completion for group names
-		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
-	}
+
 	locations, _ := locations(client)
+
 	used := args[1:]
 	for _, location := range used {
 		delete(locations, location)
 	}
+
+	group, _ := getGroup(client, args[0])
+	for _, location := range group.Locations {
+		delete(locations, location)
+	}
+
 	return maps.Keys(locations), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+func groupArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := createTursoClientFromAccessToken(false)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}
+
+	groups, _ := groupNames(client)
+	return groups, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -89,6 +89,8 @@ var groupLocationAddCmd = &cobra.Command{
 		spinner.Stop()
 		elapsed := time.Since(start)
 
+		invalidateGroupsCache(client.Org)
+
 		if len(locations) == 1 {
 			fmt.Printf("Group %s replicated to %s in %d seconds.\n", internal.Emph(group), internal.Emph(locations[0]), int(elapsed.Seconds()))
 			return nil
@@ -146,6 +148,8 @@ var groupsLocationsRmCmd = &cobra.Command{
 
 		spinner.Stop()
 		elapsed := time.Since(start)
+
+		invalidateGroupsCache(client.Org)
 
 		if len(locations) == 1 {
 			fmt.Printf("Group %s removed from %s in %d seconds.\n", internal.Emph(groupName), internal.Emph(locations[0]), int(elapsed.Seconds()))


### PR DESCRIPTION
Adds autocomplete for group commands.
- Adds autocomplete for group names (first argument of most group commands).
- Adds autocomplete for group flag in `turso db create`.
- Adds autocomplete for locations on `turso group locations add $GROUP ...`, only autocompleting missing locations.
- Adds autocomplete for locations on `turso group locations remove $GROUP ...`, only autocompleting existing locations.