### PR TITLE
Allow seeding databases with content from existing group databases

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -23,7 +23,7 @@ func init() {
 	dbCmd.AddCommand(createCmd)
 	addCanaryFlag(createCmd)
 	addGroupFlag(createCmd)
-	addForkFlag(createCmd)
+	addFromDBFlag(createCmd)
 	addEnableExtensionsFlag(createCmd)
 	addDbFromFileFlag(createCmd)
 	addLocationFlag(createCmd, "Location ID. If no ID is specified, closest location to you is used by default.")
@@ -181,7 +181,7 @@ var createCmd = &cobra.Command{
 		description := fmt.Sprintf("Creating database %s%s in %s", internal.Emph(name), dbText, internal.Emph(locationText))
 		spinner := prompt.Spinner(description)
 		defer spinner.Stop()
-		if _, err = client.Databases.Create(name, locationId, image, extensions, groupFlag, forkFlag); err != nil {
+		if _, err = client.Databases.Create(name, locationId, image, extensions, groupFlag, fromDBFlag); err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)
 		}
 

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -23,6 +23,7 @@ func init() {
 	dbCmd.AddCommand(createCmd)
 	addCanaryFlag(createCmd)
 	addGroupFlag(createCmd)
+	addForkFlag(createCmd)
 	addEnableExtensionsFlag(createCmd)
 	addDbFromFileFlag(createCmd)
 	addLocationFlag(createCmd, "Location ID. If no ID is specified, closest location to you is used by default.")
@@ -180,7 +181,7 @@ var createCmd = &cobra.Command{
 		description := fmt.Sprintf("Creating database %s%s in %s", internal.Emph(name), dbText, internal.Emph(locationText))
 		spinner := prompt.Spinner(description)
 		defer spinner.Stop()
-		if _, err = client.Databases.Create(name, locationId, image, extensions, groupFlag); err != nil {
+		if _, err = client.Databases.Create(name, locationId, image, extensions, groupFlag, forkFlag); err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)
 		}
 

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -17,10 +17,10 @@ func addGroupFlag(cmd *cobra.Command) {
 	})
 }
 
-var forkFlag string
+var fromDBFlag string
 
-func addForkFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&forkFlag, "fork", "", "fork the new database from an existing one")
-	cmd.Flags().MarkHidden("fork")
-	cmd.RegisterFlagCompletionFunc("fork", dbNameArg)
+func addFromDBFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&fromDBFlag, "from-db", "", "Creates the new database based on an existing one")
+	cmd.Flags().MarkHidden("from-db")
+	cmd.RegisterFlagCompletionFunc("from-db", dbNameArg)
 }

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -16,3 +16,11 @@ func addGroupFlag(cmd *cobra.Command) {
 		return groups, cobra.ShellCompDirectiveNoFileComp
 	})
 }
+
+var forkFlag string
+
+func addForkFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&forkFlag, "fork", "", "fork the new database from an existing one")
+	cmd.Flags().MarkHidden("fork")
+	cmd.RegisterFlagCompletionFunc("fork", dbNameArg)
+}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -72,9 +72,27 @@ type CreateDatabaseResponse struct {
 	Username string
 }
 
-func (d *DatabasesClient) Create(name, region, image, extensions, group, fork string) (*CreateDatabaseResponse, error) {
-	type Body struct{ Name, Region, Image, Extensions, Group, Fork string }
-	body, err := marshal(Body{name, region, image, extensions, group, fork})
+type DBSeed struct {
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+type CreateDatabaseBody struct {
+	Name       string  `json:"name"`
+	Location   string  `json:"location"`
+	Image      string  `json:"image,omitempty"`
+	Extensions string  `json:"extensions,omitempty"`
+	Group      string  `json:"group,omitempty"`
+	Seed       *DBSeed `json:"seed,omitempty"`
+}
+
+func (d *DatabasesClient) Create(name, location, image, extensions, group, fromDB string) (*CreateDatabaseResponse, error) {
+	params := CreateDatabaseBody{name, location, image, extensions, group, nil}
+	if fromDB != "" {
+		params.Seed = &DBSeed{fromDB, "database"}
+	}
+
+	body, err := marshal(params)
 	if err != nil {
 		return nil, fmt.Errorf("could not serialize request body: %w", err)
 	}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -72,9 +72,9 @@ type CreateDatabaseResponse struct {
 	Username string
 }
 
-func (d *DatabasesClient) Create(name, region, image, extensions, group string) (*CreateDatabaseResponse, error) {
-	type Body struct{ Name, Region, Image, Extensions, Group string }
-	body, err := marshal(Body{name, region, image, extensions, group})
+func (d *DatabasesClient) Create(name, region, image, extensions, group, fork string) (*CreateDatabaseResponse, error) {
+	type Body struct{ Name, Region, Image, Extensions, Group, Fork string }
+	body, err := marshal(Body{name, region, image, extensions, group, fork})
 	if err != nil {
 		return nil, fmt.Errorf("could not serialize request body: %w", err)
 	}


### PR DESCRIPTION
Adds the `--from-db` flag to the `turso db create` command.

Example:
```
turso db create new-db --from-db base-db
```

This will create a new database called `new-db` with schema and data copied from `base-db`.

---

Caveats:
- It will only work if `base-db` is a group database.
```
$ turso db create new-db --from-db non-group-db
Error: could not create database new-db: forked database 'non-group-db' must belong to a group
```

- It works with the `--group $GROUP` flag, but `base-db` must be inside `$GROUP`.
```
> turso db create new-db --from-db base-db --group group2
Error: could not create database new-db: can only fork databases within the same group: database base-db is not part of group group2
```
