### PR TITLE
Adapt turso db list for database groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19
+	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"fmt"
 	"sort"
 
-	"github.com/chiselstrike/iku-turso-cli/internal"
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 )
 
 func init() {
@@ -23,34 +23,80 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		databases, err := client.Databases.List()
 		if err != nil {
 			return err
 		}
 		setDatabasesCache(databases)
-		var data [][]string
-		var helps []string
-		for _, database := range databases {
-			row := []string{database.Name, getDatabaseLocations(database), getDatabaseUrl(&database)}
-			if len(database.Regions) == 0 {
-				help := fmt.Sprintf("🛠 Run %s to finish your database creation!", internal.Emph("turso db replicate "+database.Name))
-				helps = append(helps, help)
-			}
-			data = append(data, row)
-		}
 
-		sort.Slice(data, func(i, j int) bool {
-			return data[i][0] > data[j][0]
-		})
-
-		printTable([]string{"Name", "Locations", "URL"}, data)
-
-		if len(helps) > 0 {
-			fmt.Println()
-			for _, help := range helps {
-				fmt.Println(help)
-			}
-		}
+		printDBListTable(databases)
 		return nil
 	},
+}
+
+func printDBListTable(databases []turso.Database) {
+	headers, data := dbListTable(databases)
+	if !shouldPrintLocations(databases) {
+		headers, data = removeColumn(headers, data, "Locations")
+	}
+	if !shouldPrintGroups(databases) {
+		headers, data = removeColumn(headers, data, "Group")
+	}
+	printTable(headers, data)
+}
+
+func shouldPrintLocations(databases []turso.Database) bool {
+	for _, database := range databases {
+		if database.Group == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldPrintGroups(databases []turso.Database) bool {
+	mp := map[string]bool{}
+	for _, database := range databases {
+		mp[database.Group] = true
+	}
+	return len(mp) > 1
+}
+
+func dbListTable(databases []turso.Database) (headers []string, data [][]string) {
+	for _, database := range databases {
+		row := []string{database.Name, getDatabaseLocations(database), formatGroup(database.Group), getDatabaseUrl(&database)}
+		data = append(data, row)
+	}
+
+	sort.Slice(data, func(i, j int) bool {
+		return data[i][0] > data[j][0]
+	})
+
+	return []string{"Name", "Locations", "Group", "URL"}, data
+}
+
+func removeColumn(headers []string, data [][]string, column string) ([]string, [][]string) {
+	i := slices.Index(headers, column)
+	if i == -1 {
+		return headers, data
+	}
+
+	filtered := make([][]string, 0, len(data))
+	for _, row := range data {
+		filtered = append(filtered, removeIndex(row, i))
+	}
+
+	return removeIndex(headers, i), filtered
+}
+
+func removeIndex(arr []string, i int) []string {
+	return append(arr[:i], arr[i+1:]...)
+}
+
+func formatGroup(group string) string {
+	if group == "" {
+		return "-"
+	}
+	return group
 }


### PR DESCRIPTION
See https://github.com/tursodatabase/turso-cli/pull/638, for more context about this.


---

- Only print locations if there are non-group DBs
- Add group column. Print it if:
  - There are DBs in more than group
  - There is at least one group and non-group DBs
  
  --- 
  
Complete example:
```
  >  turso db list
NAME                     LOCATIONS         GROUP       URL                                               
singular-nextwave        gru (primary)     -           libsql://singular-nextwave-athoscouto.turso.io        
precious-goliath         gig (primary)     default     libsql://precious-goliath-athoscouto.turso.io         
noble-omega-sentinel     gru (primary)     bar         libsql://noble-omega-sentinel-athoscouto.turso.io     
adjusted-longshot        gig (primary)     default     libsql://adjusted-longshot-athoscouto.turso.io 
```
Example without non-group DBs:
```
> turso db list                        
NAME                     GROUP       URL                                               
precious-goliath         default     libsql://precious-goliath-athoscouto.turso.io         
noble-omega-sentinel     bar         libsql://noble-omega-sentinel-athoscouto.turso.io     
adjusted-longshot        default     libsql://adjusted-longshot-athoscouto.turso.io        
```
Example with a single group:
```
> turso db list
NAME                  URL                                            
precious-goliath      libsql://precious-goliath-athoscouto.turso.io      
adjusted-longshot     libsql://adjusted-longshot-athoscouto.turso.io
```