### PR TITLE
Enabled timestamp param in turso db create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ completions
 internal/cmd/version.txt
 .turso_history
 .vscode/
+.idea/
 cmd/turso/turso

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -165,6 +165,17 @@ var createCmd = &cobra.Command{
 			extensions = "all"
 		}
 
+		var timestamp *time.Time
+		if fromDBFlag != "" {
+			ts, err := time.Parse("2006-01-02T15:04:05", timestampFlag)
+			if err != nil {
+				return fmt.Errorf("provided timestamp was not in 'yyyy-MM-ddThh:mm::ss' format")
+			}
+			timestamp = &ts
+		} else if timestampFlag != "" {
+			return fmt.Errorf("--timestamp cannot be used without specifying --from-db option")
+		}
+
 		dbFile, err := getDbFile(fromFileFlag)
 		if err != nil {
 			return err
@@ -180,7 +191,7 @@ var createCmd = &cobra.Command{
 		description := fmt.Sprintf("Creating database %s%s in %s", internal.Emph(name), dbText, internal.Emph(locationText))
 		spinner := prompt.Spinner(description)
 		defer spinner.Stop()
-		if _, err = client.Databases.Create(name, locationId, image, extensions, groupFlag, fromDBFlag); err != nil {
+		if _, err = client.Databases.Create(name, locationId, image, extensions, groupFlag, fromDBFlag, timestamp); err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)
 		}
 

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -18,9 +18,13 @@ func addGroupFlag(cmd *cobra.Command) {
 }
 
 var fromDBFlag string
+var timestampFlag string
 
 func addFromDBFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&fromDBFlag, "from-db", "", "Creates the new database based on an existing one")
 	cmd.Flags().MarkHidden("from-db")
 	cmd.RegisterFlagCompletionFunc("from-db", dbNameArg)
+
+	cmd.Flags().StringVar(&timestampFlag, "timestamp", "", "When used with --from-db option, fork will represent state of the origin database at given point in time")
+	cmd.Flags().MarkHidden("timestamp")
 }

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
 )
@@ -79,16 +80,17 @@ type DBSeed struct {
 }
 
 type CreateDatabaseBody struct {
-	Name       string  `json:"name"`
-	Location   string  `json:"location"`
-	Image      string  `json:"image,omitempty"`
-	Extensions string  `json:"extensions,omitempty"`
-	Group      string  `json:"group,omitempty"`
-	Seed       *DBSeed `json:"seed,omitempty"`
+	Name       string     `json:"name"`
+	Location   string     `json:"location"`
+	Image      string     `json:"image,omitempty"`
+	Extensions string     `json:"extensions,omitempty"`
+	Group      string     `json:"group,omitempty"`
+	Seed       *DBSeed    `json:"seed,omitempty"`
+	Timestamp  *time.Time `json:"timestamp,omitempty"`
 }
 
-func (d *DatabasesClient) Create(name, location, image, extensions, group, fromDB string) (*CreateDatabaseResponse, error) {
-	params := CreateDatabaseBody{name, location, image, extensions, group, nil}
+func (d *DatabasesClient) Create(name, location, image, extensions, group, fromDB string, timestamp *time.Time) (*CreateDatabaseResponse, error) {
+	params := CreateDatabaseBody{name, location, image, extensions, group, nil, timestamp}
 	if fromDB != "" {
 		params.Seed = &DBSeed{fromDB, "database"}
 	}


### PR DESCRIPTION
Related to https://github.com/libsql/sqld/pull/690

Example scenario: 

```bash
turso group create {group}
turso db create {source} --group {group}

# do some work on {source} then fork it with state version at given point in time
turso db create {dest} --from-db={source} --group={group} --timestamp=2023-09-20T14:30:00
```