### PR TITLE
fix: minor stuff for overages

### DIFF
--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -85,6 +85,9 @@ var planShowCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Organization: %s\n", internal.Emph(organizationName))
+		if currentOrg.Overages {
+			plan, _ = strings.CutSuffix(plan, "_overages")
+		}
 
 		fmt.Printf("Plan: %s\n", internal.Emph(plan))
 		fmt.Print(overagesMessage(currentOrg.Overages))
@@ -253,7 +256,11 @@ var planEnableOverages = &cobra.Command{
 			fmt.Println("Payment method added successfully.")
 			fmt.Printf("You can manage your payment methods with %s.\n\n", internal.Emph("turso org billing"))
 		}
-		return client.Organizations.SetOverages(org, true)
+		if err = client.Organizations.SetOverages(org, true); err != nil {
+			return err
+		}
+		fmt.Println("Overages enabled successfully.")
+		return nil
 	},
 }
 
@@ -275,7 +282,11 @@ var planDisableOverages = &cobra.Command{
 			return err
 		}
 
-		return client.Organizations.SetOverages(org, false)
+		if err = client.Organizations.SetOverages(org, false); err != nil {
+			return err
+		}
+		fmt.Println("Overages disabled successfully.")
+		return nil
 	},
 }
 


### PR DESCRIPTION
Changed the name of the plans and it generated weird messages in the plan show. Also added messages to inform if overages was successfully changed.

After

<img width="466" alt="Screen Shot 2023-09-25 at 11 38 24 AM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/e39c220a-56e0-4b39-9fea-d21b269a1f17">


before 
<img width="485" alt="Screen Shot 2023-09-25 at 11 33 23 AM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/798b28eb-c0a5-4117-b56b-343a91b5dc64">
