### PR TITLE
Handle tokens for groups

### DIFF
--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
 
 var expFlag expirationFlag
-var readOnly bool
+var readOnlyFlag bool
+var groupTokenFlag bool
 
 func init() {
 	dbTokensCmd.AddCommand(dbGenerateTokenCmd)
@@ -18,8 +20,10 @@ func init() {
 	usage := fmt.Sprintf("Token expiration. Possible values are %s (default) or expiration time in days (e.g. %s).", internal.Emph("never"), internal.Emph("7d"))
 	dbGenerateTokenCmd.Flags().VarP(&expFlag, "expiration", "e", usage)
 	dbGenerateTokenCmd.RegisterFlagCompletionFunc("expiration", expirationFlagCompletion)
+	dbGenerateTokenCmd.Flags().BoolVar(&groupTokenFlag, "group", false, "create a token that is valid for all databases in the group")
+	dbGenerateTokenCmd.Flags().MarkHidden("group")
 
-	dbGenerateTokenCmd.Flags().BoolVarP(&readOnly, "read-only", "r", false, "Token with read-only access")
+	dbGenerateTokenCmd.Flags().BoolVarP(&readOnlyFlag, "read-only", "r", false, "Token with read-only access")
 }
 
 var dbGenerateTokenCmd = &cobra.Command{
@@ -35,20 +39,32 @@ var dbGenerateTokenCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		if _, err := getDatabase(client, name, true); err != nil {
+		database, err := getDatabase(client, name, true)
+		if err != nil {
 			return err
 		}
 		expiration := expFlag.String()
 		if err := validateExpiration(expiration); err != nil {
 			return err
 		}
-		token, err := client.Databases.Token(name, expiration, readOnly)
+		token, err := getToken(client, database, expiration, readOnlyFlag, groupTokenFlag)
 		if err != nil {
 			return fmt.Errorf("your database does not support token generation")
 		}
 		fmt.Println(token)
 		return nil
 	},
+}
+
+func getToken(client *turso.Client, database turso.Database, expiration string, readOnly, group bool) (string, error) {
+	if !group {
+		return client.Databases.Token(database.Name, expiration, readOnly)
+	}
+	if group && database.Group == "" {
+		return "", fmt.Errorf("--group flag can only be set with group databases")
+	}
+	return client.Groups.Token(database.Group, expiration, readOnly)
+
 }
 
 func validateExpiration(expiration string) error {


### PR DESCRIPTION
It adds a hidden `--group` flag to db token creation.

I don't want to create yet another auth subcommand right now, but
this should be more than enough for power users who are looking
for an option to manage multiple group database tokens.

Let's iterate with them and then we can understand the best way
to expose this.
