### PR TITLE
Try to parse error message from response on unexpected API response

### DIFF
--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -36,7 +36,7 @@ func (d *DatabasesClient) List() ([]Database, error) {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get database listing: %s", r.Status)
+		return nil, fmt.Errorf("failed to get database listing: %w", parseResponseError(r))
 	}
 
 	type ListResponse struct {
@@ -64,7 +64,7 @@ func (d *DatabasesClient) Delete(database string) error {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to delete database: %s", r.Status)
+		return fmt.Errorf("failed to delete database: %w", parseResponseError(r))
 	}
 
 	return nil

--- a/internal/turso/feedback.go
+++ b/internal/turso/feedback.go
@@ -21,7 +21,7 @@ func (d *FeedbackClient) Submit(summary, feedback string) error {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to post feedback: %s", r.Status)
+		return fmt.Errorf("failed to post feedback: %w", parseResponseError(r))
 	}
 
 	return nil

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -28,7 +28,7 @@ func (d *GroupsClient) List() ([]Group, error) {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get database groups: received status code %s", r.Status)
+		return nil, fmt.Errorf("failed to get database groups: received status code%w", parseResponseError(r))
 	}
 
 	type ListResponse struct {
@@ -55,7 +55,7 @@ func (d *GroupsClient) Get(name string) (Group, error) {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return Group{}, fmt.Errorf("failed to get database group: received status code %s", r.Status)
+		return Group{}, fmt.Errorf("failed to get database group: received status code%w", parseResponseError(r))
 	}
 
 	type Response struct {
@@ -83,7 +83,7 @@ func (d *GroupsClient) Delete(group string) error {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to delete group: received status code %s", r.Status)
+		return fmt.Errorf("failed to delete group: received status code%w", parseResponseError(r))
 	}
 
 	return nil

--- a/internal/turso/locations.go
+++ b/internal/turso/locations.go
@@ -35,7 +35,7 @@ func (c *LocationsClient) List() (map[string]string, error) {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get locations: %s", r.Status)
+		return nil, fmt.Errorf("failed to get locations: %w", parseResponseError(r))
 
 	}
 
@@ -81,7 +81,7 @@ func (c *LocationsClient) Closest() (string, error) {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to get closest location: %s", r.Status)
+		return "", fmt.Errorf("failed to get closest location: %w", parseResponseError(r))
 
 	}
 

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -26,7 +26,7 @@ func (c *OrganizationsClient) List() ([]Organization, error) {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list organizations: %s", r.Status)
+		return nil, fmt.Errorf("failed to list organizations: %w", parseResponseError(r))
 	}
 
 	type ListResponse struct {
@@ -62,7 +62,7 @@ func (c *OrganizationsClient) Create(name string, stripeId string, dryRun bool) 
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return Organization{}, fmt.Errorf("failed to create organization: %s", r.Status)
+		return Organization{}, fmt.Errorf("failed to create organization: %w", parseResponseError(r))
 	}
 
 	data, err := unmarshal[struct{ Org Organization }](r)
@@ -92,7 +92,7 @@ func (c *OrganizationsClient) Delete(slug string) error {
 	case http.StatusForbidden:
 		return fmt.Errorf("you do not have permission to delete organization %s", slug)
 	default:
-		return fmt.Errorf("failed to delete organization: %s", r.Status)
+		return fmt.Errorf("failed to delete organization: %w", parseResponseError(r))
 	}
 }
 
@@ -151,7 +151,7 @@ func (c *OrganizationsClient) SetOverages(slug string, toggle bool) error {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to set overages: %s", r.Status)
+		return fmt.Errorf("failed to set overages: %w", parseResponseError(r))
 	}
 
 	return nil
@@ -184,7 +184,7 @@ func (c *OrganizationsClient) ListMembers() ([]Member, error) {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list organization members: %s", r.Status)
+		return nil, fmt.Errorf("failed to list organization members: %w", parseResponseError(r))
 	}
 
 	data, err := unmarshal[struct{ Members []Member }](r)
@@ -217,7 +217,7 @@ func (c *OrganizationsClient) AddMember(username, role string) error {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to add organization member: %s", r.Status)
+		return fmt.Errorf("failed to add organization member: %w", parseResponseError(r))
 	}
 
 	return nil
@@ -245,7 +245,7 @@ func (c *OrganizationsClient) InviteMember(email, role string) error {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to invite organization member: %s", r.Status)
+		return fmt.Errorf("failed to invite organization member: %w", parseResponseError(r))
 	}
 
 	return nil
@@ -268,7 +268,7 @@ func (c *OrganizationsClient) RemoveMember(username string) error {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to remove organization member: %s", r.Status)
+		return fmt.Errorf("failed to remove organization member: %w", parseResponseError(r))
 	}
 
 	return nil

--- a/internal/turso/token.go
+++ b/internal/turso/token.go
@@ -15,7 +15,7 @@ func (c *TokensClient) Validate(token string) (int64, error) {
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("failed to validate token: %s", r.Status)
+		return 0, fmt.Errorf("failed to validate token: %w", parseResponseError(r))
 	}
 
 	data, err := unmarshal[struct{ Exp int64 }](r)


### PR DESCRIPTION
Before:
```
turso org create FOO
Error: failed to create organization: 400 Bad Request
```

After:
```
> turso org create FOO
Error: failed to create organization: invalid organization name: FOO
```

We can still improve, but the changes should be done on the API.