### PR TITLE
Fix turso db locations -l

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -149,9 +149,7 @@ func latencies(client *turso.Client) (map[string]int, error) {
 					measure = int(math.Min(float64(d.Milliseconds()), float64(measure)))
 				}
 			}
-			if measure != math.MaxInt {
-				c <- latMap{id: id, lat: measure}
-			}
+			c <- latMap{id: id, lat: measure}
 
 		}(id)
 	}

--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
@@ -65,7 +66,7 @@ var regionsCmd = &cobra.Command{
 			description := locations[location]
 			lat, ok := lats[location]
 			var latency string
-			if ok {
+			if ok && lat != math.MaxInt {
 				latency = fmt.Sprintf("%dms", lat)
 			} else {
 				latency = "???"

--- a/internal/turso/locations.go
+++ b/internal/turso/locations.go
@@ -102,11 +102,23 @@ func ProbeLocation(location string) *time.Duration {
 	req.Header.Add("fly-prefer-region", location)
 
 	start := time.Now()
-	_, err = client.Do(req)
+	r, err := client.Do(req)
 	if err != nil {
 		return nil
 	}
+	defer r.Body.Close()
+
 	dur := time.Since(start)
+	if r.StatusCode != http.StatusOK {
+		return nil
+	}
+	data, err := unmarshal[ClosestLocationResponse](r)
+	if err != nil {
+		return nil
+	}
+	if data.Server != location {
+		return nil
+	}
 	return &dur
 }
 


### PR DESCRIPTION
`region.turso.io` with `fly-prefer-region` only works on a best-effort basis.
If Fly can't route to that region, it will route to the closest one available. 
We need to take that into account and look for the actual region the response came from (it comes in the response body).