### PR TITLE
Drop groups cache on DB destroy

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -137,6 +137,7 @@ func destroyDatabases(client *turso.Client, names []string) error {
 	}
 
 	invalidateDatabasesCache()
+	invalidateGroupsCache(client.Org)
 	invalidateDbTokenCache()
 	settings.PersistChanges()
 


### PR DESCRIPTION
We can automatically destroy the group with the database, so we need to drop group cache as well.