### PR TITLE
Fix CLI update suggestion formatting

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -206,8 +206,8 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 
 		fmt.Printf("\nFriendly reminder that there's a newer version of %s available.\n", internal.Emph("Turso CLI"))
 		fmt.Printf("You're currently using version %s while latest available version is %s.\n", internal.Emph(version), internal.Emph(latestVersion))
-		fmt.Printf("Please consider updating to get new features and more stable experience. To update:\n\n")
-		fmt.Printf("\n\t%s\n", internal.Emph("turso update"))
+		fmt.Printf("Please consider updating to get new features and more stable experience. To update:\n")
+		fmt.Printf("\n\t%s\n\n", internal.Emph("turso update"))
 	}
 
 	return nil


### PR DESCRIPTION
Currently, the CLI update suggestion has botched newlines and looks like this:

```
You're currently using version v0.85.3 while latest available version is v0.86.3.
Please consider updating to get new features and more stable experience. To update:


	turso update
```

Fix it to look sensible:

```
You're currently using version v0.85.3 while latest available version is v0.86.3.
Please consider updating to get new features and more stable experience. To update:

	turso update

```