### PR TITLE
Bind turso base URL to config

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -21,6 +21,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	tursoDefaultBaseURL = "https://api.turso.tech"
+)
+
 func createTursoClientFromAccessToken(warnMultipleAccessTokenSources bool) (*turso.Client, error) {
 	token, err := getAccessToken(warnMultipleAccessTokenSources)
 	if err != nil {
@@ -248,11 +252,12 @@ func deleteDatabaseInstance(client *turso.Client, database, instance string) err
 }
 
 func getTursoUrl() string {
-	host := os.Getenv("TURSO_API_BASEURL")
-	if host == "" {
-		host = "https://api.turso.tech"
+	config, _ := settings.ReadSettings() // ok to ignore, we'll fallback to default
+	url := config.GetBaseURL()
+	if url == "" {
+		url = tursoDefaultBaseURL
 	}
-	return host
+	return url
 }
 
 func promptConfirmation(prompt string) (bool, error) {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -32,6 +32,7 @@ func ReadSettings() (*Settings, error) {
 
 	configPath := configdir.LocalConfig("turso")
 	viper.BindEnv("config-path", "TURSO_CONFIG_FOLDER")
+	viper.BindEnv("baseURL", "TURSO_API_BASEURL")
 
 	configPathFlag := viper.GetString("config-path")
 	if len(configPathFlag) > 0 {
@@ -119,6 +120,10 @@ func (s *Settings) SetUsername(username string) {
 
 func (s *Settings) GetUsername() string {
 	return viper.GetString("username")
+}
+
+func (s *Settings) GetBaseURL() string {
+	return viper.GetString("baseURL")
 }
 
 func (s *Settings) SetAutoupdate(autoupdate string) {


### PR DESCRIPTION
Once the base URL is overridden, its value will bind to the configuration file.
This facilitates managing local vs remote API setup since you only need to use a single env var (`TURSO_CONFIG_FOLDER`).