### PR TITLE
Add --queries flag to inspect command

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var queriesFlag bool
+
+func addQueriesFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&queriesFlag, "queries", false, "Display database queries statistics")
+}


### PR DESCRIPTION
It displays top queries the consumed rows read and rows written quotas.

---

Example:
```
$ turso db inspect evolved-new-goblin --queries
QUERY                           ROWS WRITTEN  ROWS READ  
INSERT INTO a SELECT * FROM a;  131072        262144     
INSERT INTO a SELECT * FROM a;  65536         131072     
INSERT INTO a SELECT * FROM a;  32768         65536      
INSERT INTO a SELECT * FROM a;  16384         32768      
INSERT INTO a SELECT * FROM a;  8192          16384      
INSERT INTO a SELECT * FROM a;  4096          8192       
INSERT INTO a SELECT * FROM a;  2048          4096       
INSERT INTO a SELECT * FROM a;  1024          2048       
INSERT INTO a SELECT * FROM a;  512           1024       
INSERT INTO a SELECT * FROM a;  256           512        

$
```