### PR TITLE
fix: wait after creating group before creating database

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -100,7 +100,10 @@ func ensureGroup(client *turso.Client, group, location, version string) error {
 	if ok, err := shouldCreateGroup(client, group, location); !ok {
 		return err
 	}
-	return createGroup(client, group, location, version)
+	if err := createGroup(client, group, location, version); err != nil {
+		return err
+	}
+	return client.Groups.WaitLocation(group, location)
 }
 
 func getDatabaseName(args []string) (string, error) {


### PR DESCRIPTION
this should avoid errors like this in db creation without groups https://chiselstrike.slack.com/archives/C04UA0978UD/p1699972599881909