### PR TITLE
Fix typo and sqld build link path - `turso dev`

### DIFF
--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -75,8 +75,8 @@ var devCmd = &cobra.Command{
 		// Start the server process
 		err = sqld.Start()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s.\no install it, follow the instructions at %s\nAlso make sure %s is on your PATH\n", internal.Warn("Could not start libsql-server"),
-				internal.Emph("https://github.com/tursodatabase/libsql/blob/main/libsql-server/docs/BUILD-RUN.md"),
+			fmt.Fprintf(os.Stderr, "%s.\nTo install it, follow the instructions at %s\nAlso make sure %s is on your PATH\n", internal.Warn("Could not start libsql-server"),
+				internal.Emph("https://github.com/tursodatabase/libsql/blob/main/docs/BUILD-RUN.md"),
 				internal.Emph("sqld"))
 			return err
 		}


### PR DESCRIPTION
There was a typo in `turso dev` output along with the path being wrong for build instructions for sqld.
This PR fixes both.


Thanks,
-8x4