### PR TITLE
Updated libsql install instructions link

### DIFF
--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -75,8 +75,8 @@ var devCmd = &cobra.Command{
 		// Start the server process
 		err = sqld.Start()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s.\no install it, follow the instructions at %s\nAlso make sure %s is on your PATH\n", internal.Warn("Could not start libsql-server"),
-				internal.Emph("https://github.com/tursodatabase/libsql/blob/main/libsql-server/docs/BUILD-RUN.md"),
+			fmt.Fprintf(os.Stderr, "%s.\nTo install it, follow the instructions at %s\nAlso make sure %s is on your PATH\n", internal.Warn("Could not start libsql-server"),
+				internal.Emph("https://github.com/tursodatabase/libsql/blob/main/docs/BUILD-RUN.md"),
 				internal.Emph("sqld"))
 			return err
 		}


### PR DESCRIPTION
- Also I assume it was meant to be "To install it[...]" - so updated that too

Looks like it's a duplicate of https://github.com/tursodatabase/turso-cli/pull/725 - sorry!