### PR TITLE
show time in milliseconds for fast operations

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -83,7 +83,7 @@ var createCmd = &cobra.Command{
 
 		spinner.Stop()
 		elapsed := time.Since(start)
-		fmt.Printf("Created database %s at group %s in %d seconds.\n\n", internal.Emph(name), internal.Emph(group), int(elapsed.Seconds()))
+		fmt.Printf("Created database %s at group %s in %s.\n\n", internal.Emph(name), internal.Emph(group), elapsed.Round(time.Millisecond).String())
 
 		fmt.Printf("Start an interactive SQL shell with:\n\n")
 		fmt.Printf("   %s\n\n", internal.Emph("turso db shell "+name))

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -132,7 +132,7 @@ func createGroup(client *turso.Client, name, location, version string) error {
 
 	spinner.Stop()
 	elapsed := time.Since(start)
-	fmt.Printf("Created group %s at %s in %d seconds.\n", internal.Emph(name), internal.Emph(location), int(elapsed.Seconds()))
+	fmt.Printf("Created group %s at %s in %s.\n", internal.Emph(name), internal.Emph(location), elapsed.Round(time.Millisecond).String())
 
 	return nil
 }
@@ -149,7 +149,7 @@ func destroyGroup(client *turso.Client, name string) error {
 	s.Stop()
 	elapsed := time.Since(start)
 
-	fmt.Printf("Destroyed group %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
+	fmt.Printf("Destroyed group %s in %s.\n", internal.Emph(name), elapsed.Round(time.Millisecond).String())
 	return nil
 }
 

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -172,7 +172,7 @@ func destroyDatabases(client *turso.Client, names []string) error {
 
 	msg = fmt.Sprintf("Destroyed %d databases in %d seconds.\n", len(names), int(elapsed.Seconds()))
 	if len(names) == 1 {
-		msg = fmt.Sprintf("Destroyed database %s in %d seconds.\n", internal.Emph(names[0]), int(elapsed.Seconds()))
+		msg = fmt.Sprintf("Destroyed database %s in %s.\n", internal.Emph(names[0]), elapsed.Round(time.Millisecond).String())
 	}
 	fmt.Println(msg)
 


### PR DESCRIPTION
Right now we print "0 seconds". It's better to show the actual number of milliseconds.