### PR TITLE
Add libsql as a dependency

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Verify CLI installation
         run: turso --version
+
+      - name: Verify libsql server installation
+        run: sqld --version

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,8 @@ brews:
     tap:
       owner: tursodatabase
       name: homebrew-tap
+    dependencies:
+      - name: libsql/sqld/libsql-server
     install: |
       bin.install "turso"
       bash_completion.install "completions/turso.bash" => "turso"


### PR DESCRIPTION
This PR updates our Homebrew formula to include libsql as a dependency. The final generated formula looks like following: 

```yaml
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class Turso < Formula
  desc ""
  homepage "https://github.com/tursodatabase/homebrew-tap"
  version "0.87.6"

  depends_on "libsql/sqld/libsql-server"

  on_macos do
    if Hardware::CPU.arm?
      url "https://github.com/tursodatabase/homebrew-tap/releases/download/v0.87.6/homebrew-tap_Darwin_arm64.tar.gz"
      sha256 "915ca542f0c9b8ce2e65b7583ce360f23bc90ca31e4cc6392162f3b30c8328ef"

      def install
        bin.install "turso"
        bash_completion.install "completions/turso.bash" => "turso"
        zsh_completion.install "completions/turso.zsh" => "_turso"
        fish_completion.install "completions/turso.fish"
      end
    end
    if Hardware::CPU.intel?
      url "https://github.com/tursodatabase/homebrew-tap/releases/download/v0.87.6/homebrew-tap_Darwin_x86_64.tar.gz"
      sha256 "d27c43f9e0854eab5bd12e4d237884f07d88a671f8872146d82f12c9f38e2eb1"

      def install
        bin.install "turso"
        bash_completion.install "completions/turso.bash" => "turso"
        zsh_completion.install "completions/turso.zsh" => "_turso"
        fish_completion.install "completions/turso.fish"
      end
    end
  end

  on_linux do
    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
      url "https://github.com/tursodatabase/homebrew-tap/releases/download/v0.87.6/homebrew-tap_Linux_arm64.tar.gz"
      sha256 "7d3290dd8cb46e87dd5d3cf8478cb32c61890a34dcfc95d75234f577635d978e"

      def install
        bin.install "turso"
        bash_completion.install "completions/turso.bash" => "turso"
        zsh_completion.install "completions/turso.zsh" => "_turso"
        fish_completion.install "completions/turso.fish"
      end
    end
    if Hardware::CPU.intel?
      url "https://github.com/tursodatabase/homebrew-tap/releases/download/v0.87.6/homebrew-tap_Linux_x86_64.tar.gz"
      sha256 "71da7f47fa84ef210d165d124e7f3da0b4e8de288a6e0ea0b2e4072711b3dd96"

      def install
        bin.install "turso"
        bash_completion.install "completions/turso.bash" => "turso"
        zsh_completion.install "completions/turso.zsh" => "_turso"
        fish_completion.install "completions/turso.fish"
      end
    end
  end

  def post_install
    exec('turso quickstart')
  end
end
```

Only one line is the diff:

```diff
+ depends_on "libsql/sqld/libsql-server"
```

This is generated by doing a goreleaser dry run: 

```
goreleaser --skip-validate --skip-publish --clean
```