### PR TITLE
Improve error message for `turso db shell http://badurl:8000`

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -180,9 +180,9 @@ var shellCmd = &cobra.Command{
 			shellErr := strings.Split(err.Error(), "\n")
 			var serverErr string
 			if 1 < len(shellErr) {
-				serverErr = "\n" + shellErr[1]
+				serverErr = shellErr[1]
 			}
-			return fmt.Errorf("connection to %s failed. Is this a valid URI?%s", internal.Emph(shellConfig.DbUri), serverErr)
+			return fmt.Errorf("connection to %s failed. %s", internal.Emph(shellConfig.DbUri), serverErr)
 		}
 
 		return nil

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/libsql/libsql-shell-go/pkg/shell"
@@ -174,7 +175,17 @@ var shellCmd = &cobra.Command{
 			return shell.RunShellLine(shellConfig, string(b))
 		}
 
-		return shell.RunShell(shellConfig)
+		err := shell.RunShell(shellConfig)
+		if err != nil {
+			shellErr := strings.Split(err.Error(), "\n")
+			var serverErr string
+			if 1 < len(shellErr) {
+				serverErr = "\n" + shellErr[1]
+			}
+			return fmt.Errorf("connection to %s failed. Is this a valid URI?%s", internal.Emph(shellConfig.DbUri), serverErr)
+		}
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
PR for issue https://github.com/tursodatabase/turso-cli/issues/694

The goal being to remove the obscured `Error: failed to connect to database. err: failed to execute SQL: SELECT 1;` error, but keep the improved specific error with an error code added in https://github.com/tursodatabase/libsql-client-go/pull/81

### Examples
![Screenshot from 2023-12-19 19-37-02](https://github.com/tursodatabase/turso-cli/assets/69766831/30cb1f68-9c0f-4dbf-b677-6437be33d331)
