### PR TITLE
use a valid token name as an example

### DIFF
--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 var createApiTokensCmd = &cobra.Command{
-	Use:   "mint api_token_name",
+	Use:   "mint api-token-name",
 	Short: "Mint an API token.",
 	Long: "" +
 		"API tokens are revocable non-expiring tokens that authenticate holders as the user who minted them.\n" +

--- a/internal/cmd/auth_revokeapitokens.go
+++ b/internal/cmd/auth_revokeapitokens.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 var revokeApiTokensCmd = &cobra.Command{
-	Use:   "revoke api_token_name",
+	Use:   "revoke api-token-name",
 	Short: "Revoke an API token.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Token name we use as example is not valid, since it contains _