### PR TITLE
chore: Log which environment variable is set

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -320,7 +320,7 @@ func verifyIfTokenIsSetInEnv(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 	envToken := os.Getenv(ENV_ACCESS_TOKEN)
 	if envToken != "" {
-		return fmt.Errorf("auth commands aren't effective when a token is set in the environment variable")
+		return fmt.Errorf("auth commands aren't effective when a token is set in the environment variable: %s", ENV_ACCESS_TOKEN)
 	}
 
 	return nil


### PR DESCRIPTION
This address issue #608 to show which environment variable the token is being pulled from.