### PR TITLE
docs: update arg placeholders to use the same style

### DIFF
--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 var createApiTokensCmd = &cobra.Command{
-	Use:   "mint api-token-name",
+	Use:   "mint <api-token-name>",
 	Short: "Mint an API token.",
 	Long: "" +
 		"API tokens are revocable non-expiring tokens that authenticate holders as the user who minted them.\n" +

--- a/internal/cmd/auth_revokeapitokens.go
+++ b/internal/cmd/auth_revokeapitokens.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 var revokeApiTokensCmd = &cobra.Command{
-	Use:   "revoke api-token-name",
+	Use:   "revoke <api-token-name>",
 	Short: "Revoke an API token.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 var createCmd = &cobra.Command{
-	Use:               "create [flags] [database_name]",
+	Use:               "create [flags] [database-name]",
 	Short:             "Create a database.",
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: noFilesArg,

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -19,7 +19,7 @@ func init() {
 }
 
 var destroyCmd = &cobra.Command{
-	Use:               "destroy database_name",
+	Use:               "destroy <database-name>",
 	Short:             "Destroy a database.",
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: dbNameArg,

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 var dbGenerateTokenCmd = &cobra.Command{
-	Use:               "create database_name",
+	Use:               "create <database-name>",
 	Short:             "Creates a bearer token to authenticate requests to the database",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: dbNameArg,

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -83,7 +83,7 @@ func (curr *InspectInfo) TotalRowsReadCount() uint64 {
 }
 
 var dbInspectCmd = &cobra.Command{
-	Use:               "inspect {database_name}",
+	Use:               "inspect <database-name>",
 	Short:             "Inspect database.",
 	Example:           "turso db inspect name-of-my-amazing-db",
 	Args:              cobra.RangeArgs(1, 2),

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 var dbInvalidateTokensCmd = &cobra.Command{
-	Use:               "invalidate database_name",
+	Use:               "invalidate <database-name>",
 	Short:             "Rotates the keys used to create and verify database tokens making existing tokens invalid",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: dbNameArg,
@@ -65,7 +65,7 @@ func rotateAndNotify(turso *turso.Client, database turso.Database) error {
 
 	s.Stop()
 	fmt.Println("✔  Success! Tokens invalidated successfully. ")
-	fmt.Printf("Run %s to get a new one!\n", internal.Emph("turso db tokens create database_name [flags]"))
+	fmt.Printf("Run %s to get a new one!\n", internal.Emph("turso db tokens create <database-name> [flags]"))
 	return nil
 }
 

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var replicateCmd = &cobra.Command{
-	Use:               "replicate <database-name> [location-id]",
+	Use:               "replicate <database-name> <location-code>,
 	Short:             "Replicate a database.",
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: replicateArgs,

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var replicateCmd = &cobra.Command{
-	Use:               "replicate database_name location_id",
+	Use:               "replicate <database-name> location_id",
 	Short:             "Replicate a database.",
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: replicateArgs,

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var replicateCmd = &cobra.Command{
-	Use:               "replicate <database-name> <location-code>,
+	Use:               "replicate <database-name> <location-code>",
 	Short:             "Replicate a database.",
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: replicateArgs,

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var replicateCmd = &cobra.Command{
-	Use:               "replicate <database-name> location_id",
+	Use:               "replicate <database-name> [location-id]",
 	Short:             "Replicate a database.",
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: replicateArgs,

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -56,9 +56,9 @@ func getURL(db *turso.Database, client *turso.Client) (string, error) {
 }
 
 var shellCmd = &cobra.Command{
-	Use:               "shell {database_name | replica_url} [sql]",
+	Use:               "shell <database-name | replica-url> [sql]",
 	Short:             "Start a SQL shell.",
-	Long:              "Start a SQL shell.\nWhen database_name is provided, the shell will connect the closest replica of the specified database.\nWhen the --instance flag is provided with a specific instance name, the shell will connect to that instance directly.",
+	Long:              "Start a SQL shell.\nWhen database-name is provided, the shell will connect the closest replica of the specified database.\nWhen the --instance flag is provided with a specific instance name, the shell will connect to that instance directly.",
 	Example:           "  turso db shell http://127.0.0.1:8080\n  turso db shell name-of-my-amazing-db\n  turso db shell name-of-my-amazing-db --location yyz\n  turso db shell name-of-my-amazing-db --instance a-specific-instance\n  turso db shell name-of-my-amazing-db \"select * from users;\"",
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: dbNameArg,

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var showCmd = &cobra.Command{
-	Use:               "show database_name",
+	Use:               "show <database-name>",
 	Short:             "Show information from a database.",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: dbNameArg,

--- a/internal/cmd/db_transfer.go
+++ b/internal/cmd/db_transfer.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 var dbTransferCmd = &cobra.Command{
-	Use:               "db-transfer database_name org_name",
+	Use:               "db-transfer <database-name> <organization-name>",
 	Short:             "Transfers a database to another organization",
 	Args:              cobra.ExactArgs(2),
 	ValidArgsFunction: dbNameAndOrgArgs,

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 var dbUpdateCmd = &cobra.Command{
-	Use:               "update database_name",
+	Use:               "update <database-name>",
 	Short:             "Updates the database to the latest turso version",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: dbNameArg,

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -50,7 +50,7 @@ var groupsListCmd = &cobra.Command{
 }
 
 var groupsCreateCmd = &cobra.Command{
-	Use:               "create [group]",
+	Use:               "create <group-name>",
 	Short:             "Create a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
@@ -84,7 +84,7 @@ var groupsCreateCmd = &cobra.Command{
 }
 
 var unarchiveGroupCmd = &cobra.Command{
-	Use:               "wakeup [group]",
+	Use:               "wakeup <group-name>",
 	Short:             "Wake up a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: groupArgs,
@@ -101,7 +101,7 @@ var unarchiveGroupCmd = &cobra.Command{
 }
 
 var groupsDestroyCmd = &cobra.Command{
-	Use:               "destroy [group]",
+	Use:               "destroy <group-name>",
 	Short:             "Destroy a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: groupArgs,

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -51,7 +51,7 @@ var groupLocationsListCmd = &cobra.Command{
 }
 
 var groupLocationAddCmd = &cobra.Command{
-	Use:               "add <group-name> [...locations]",
+	Use:               "add <group-name> <...location-code>",
 	Short:             "Add locations to a database group",
 	Args:              cobra.MinimumNArgs(2),
 	ValidArgsFunction: locationsAddArgs,

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 var groupLocationsListCmd = &cobra.Command{
-	Use:               "list [group]",
+	Use:               "list <group-name>",
 	Short:             "List database group locations",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
@@ -51,7 +51,7 @@ var groupLocationsListCmd = &cobra.Command{
 }
 
 var groupLocationAddCmd = &cobra.Command{
-	Use:               "add [group] [...locations]",
+	Use:               "add <group-name> [...locations]",
 	Short:             "Add locations to a database group",
 	Args:              cobra.MinimumNArgs(2),
 	ValidArgsFunction: locationsAddArgs,
@@ -118,7 +118,7 @@ var groupLocationAddCmd = &cobra.Command{
 }
 
 var groupsLocationsRmCmd = &cobra.Command{
-	Use:               "remove [group] [...locations]",
+	Use:               "remove <group-name> [...locations]",
 	Short:             "Remove locations from a database group",
 	Args:              cobra.MinimumNArgs(2),
 	ValidArgsFunction: locationsRmArgs,

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -118,7 +118,7 @@ var groupLocationAddCmd = &cobra.Command{
 }
 
 var groupsLocationsRmCmd = &cobra.Command{
-	Use:               "remove <group-name> [...locations]",
+	Use:               "remove <group-name> <...location-code>",
 	Short:             "Remove locations from a database group",
 	Args:              cobra.MinimumNArgs(2),
 	ValidArgsFunction: locationsRmArgs,

--- a/internal/cmd/group_update.go
+++ b/internal/cmd/group_update.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 var groupUpdateCmd = &cobra.Command{
-	Use:               "update group_name",
+	Use:               "update <group-name>",
 	Short:             "Updates the group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: groupArg,

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -121,7 +121,7 @@ var orgListCmd = &cobra.Command{
 }
 
 var orgCreateCmd = &cobra.Command{
-	Use:               "create <name>",
+	Use:               "create <organization-name>",
 	Short:             "Create a new organization",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
@@ -220,7 +220,7 @@ var orgDestroyCmd = &cobra.Command{
 }
 
 var orgSwitchCmd = &cobra.Command{
-	Use:               "switch <slug>",
+	Use:               "switch <organization-slug>",
 	Short:             "Switch to an organization as the context for your commands.",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg, // TODO: add orgs autocomplete


### PR DESCRIPTION
We should adhere to a common format when describing required and optional arguments for commands.

Typically, the standards are follows:

* `<required arg>`
* `[optional option]`

But we've been using the following:

* `[database_name]`
* `database_name`
* `[group]`

I also added the required `<>` formatting to to `api-token-name` since that didn't use it.

I'm open to changing `<database-name>`/`<api-token-name>` to `<database_name>`/`<api_token_name>`. It's not clear which format we prefer.