### PR TITLE
feat: new quickstart command

### DIFF
--- a/internal/cmd/quickstart.go
+++ b/internal/cmd/quickstart.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	"github.com/tursodatabase/turso-cli/internal"
 )
 
 func init() {
@@ -13,17 +13,22 @@ func init() {
 
 var quickstartCmd = &cobra.Command{
 	Use:               "quickstart",
-	Short:             "Turso quick quickstart.",
+	Short:             "New to Turso? Start here!",
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
+
 		fmt.Print("\nWelcome to Turso!\n\n")
-		fmt.Printf("If you are a new user, please sign up with %s; otherwise login\n", internal.Emph("turso auth signup"))
-		fmt.Printf("with %s. When you are authenticated, you can create a new\n", internal.Emph("turso auth login"))
-		fmt.Printf("database with %s. You can also run %s for help.\n", internal.Emph("turso db create"), internal.Emph("turso help"))
-		fmt.Printf("\nFor a more comprehensive getting started guide, open the following URL:\n\n")
-		fmt.Printf("  https://docs.turso.tech/tutorials/get-started-turso-cli\n\n")
+
+		quickstartURL := "https://docs.turso.tech/quickstart"
+
+		if err := browser.OpenURL(quickstartURL); err != nil {
+			fmt.Printf("To get started with Turso, open the following URL in your browser:\n\n")
+			fmt.Println(quickstartURL)
+		} else {
+			fmt.Println("Opening Turso Quickstart Guide in your browser...")
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
Hey 👋🏻 

What do we think about this change?

I want to provide a clearer onboarding journey for CLI users that may have recently installed it and run `turso quickstart`.

The updated command will attempt to open the browser and launch the new quickstart.

Please note: The new URL is a 404 because our new docs haven't launched yet. I will create a PR in the current docs to handle this redirect so we don't need to update the CLI later with another link.