### PR TITLE
feat(auth): print the env var name 

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -320,7 +320,7 @@ func verifyIfTokenIsSetInEnv(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 	envToken := os.Getenv(ENV_ACCESS_TOKEN)
 	if envToken != "" {
-		return fmt.Errorf("auth commands aren't effective when a token is set in the environment variable")
+		return fmt.Errorf("auth commands aren't effective when a token is set in the %q environment variable", ENV_ACCESS_TOKEN)
 	}
 
 	return nil

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -106,7 +106,7 @@ func getAccessToken(warnMultipleAccessTokenSources bool) (string, error) {
 	settingsToken := settings.GetToken()
 
 	if !noMultipleTokenSourcesWarning && envToken != "" && settingsToken != "" && warnMultipleAccessTokenSources {
-		fmt.Printf("Warning: User logged in as %s but TURSO_API_TOKEN environment variable is set so proceeding to use it instead\n\n", settings.GetUsername())
+		fmt.Printf("Warning: User logged in as %s but %q environment variable is set so proceeding to use it instead\n\n", settings.GetUsername(), ENV_ACCESS_TOKEN)
 	}
 	if envToken != "" {
 		return envToken, nil


### PR DESCRIPTION
Context

I wasted some time when I encountered this error message 
```
auth commands aren't effective when a token is set in the environment variable
```
While running some CLI commands.

I had no idea which environment variable was being read and where it was.

After I found that it was `TURSO_API_TOKEN` I then did 
```
export TURSO_API_TOKEN=
```
To get unblocked and could run the CLI commands successfully.
