### PR TITLE
Change how env and config auth tokens are handled

### DIFF
--- a/internal/cmd/account_feedback.go
+++ b/internal/cmd/account_feedback.go
@@ -16,7 +16,7 @@ var accountFeedbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return fmt.Errorf("could not create turso client: %w", err)
 		}

--- a/internal/cmd/account_feedback.go
+++ b/internal/cmd/account_feedback.go
@@ -16,7 +16,7 @@ var accountFeedbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return fmt.Errorf("could not create turso client: %w", err)
 		}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -199,7 +199,7 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 		fmt.Printf("✔  Success! Logged in as %s\n", username)
 
 		firstTime := settings.RegisterUse("auth_login")
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -300,7 +300,7 @@ func logout(cmd *cobra.Command, args []string) error {
 
 func whoAmI(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceUsage = true
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -199,7 +199,7 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 		fmt.Printf("✔  Success! Logged in as %s\n", username)
 
 		firstTime := settings.RegisterUse("auth_login")
-		client, err := createTursoClientFromAccessToken(false)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -300,7 +300,7 @@ func logout(cmd *cobra.Command, args []string) error {
 
 func whoAmI(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceUsage = true
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -26,7 +26,6 @@ var authCmd = &cobra.Command{
 	Use:               "auth",
 	Short:             "Authenticate with Turso",
 	ValidArgsFunction: noSpaceArg,
-	PersistentPreRunE: verifyIfTokenIsSetInEnv,
 }
 
 var signupCmd = &cobra.Command{
@@ -35,6 +34,7 @@ var signupCmd = &cobra.Command{
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE:              signup,
+	PersistentPreRunE: checkEnvAuth,
 }
 
 var loginCmd = &cobra.Command{
@@ -43,6 +43,7 @@ var loginCmd = &cobra.Command{
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE:              login,
+	PersistentPreRunE: checkEnvAuth,
 }
 
 var logoutCmd = &cobra.Command{
@@ -51,6 +52,7 @@ var logoutCmd = &cobra.Command{
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE:              logout,
+	PersistentPreRunE: checkEnvAuth,
 }
 
 var whoAmICmd = &cobra.Command{
@@ -212,7 +214,6 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 	latestVersion := <-versionChannel
 
 	if version != "dev" && version != latestVersion {
-
 		fmt.Printf("\nFriendly reminder that there's a newer version of %s available.\n", internal.Emph("Turso CLI"))
 		fmt.Printf("You're currently using version %s while latest available version is %s.\n", internal.Emph(version), internal.Emph(latestVersion))
 		fmt.Printf("Please consider updating to get new features and more stable experience. To update:\n")
@@ -312,16 +313,11 @@ func whoAmI(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func verifyIfTokenIsSetInEnv(cmd *cobra.Command, args []string) error {
-	// we want to override this for `turso auth whoami`
-	if cmd.Use == whoAmICmd.Use {
-		return nil
-	}
+func checkEnvAuth(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
-	envToken := os.Getenv(ENV_ACCESS_TOKEN)
-	if envToken != "" {
-		return fmt.Errorf("auth commands aren't effective when a token is set in the %q environment variable", ENV_ACCESS_TOKEN)
+	token := os.Getenv(ENV_ACCESS_TOKEN)
+	if token != "" {
+		return fmt.Errorf("a token is set in the %q environment variable, please unset it before running %s", ENV_ACCESS_TOKEN, internal.Emph(cmd.CommandPath()))
 	}
-
 	return nil
 }

--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -24,7 +24,7 @@ var createApiTokensCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -24,7 +24,7 @@ var createApiTokensCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/auth_listapitokens.go
+++ b/internal/cmd/auth_listapitokens.go
@@ -19,7 +19,7 @@ var listApiTokensCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/auth_listapitokens.go
+++ b/internal/cmd/auth_listapitokens.go
@@ -19,7 +19,7 @@ var listApiTokensCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/auth_revokeapitokens.go
+++ b/internal/cmd/auth_revokeapitokens.go
@@ -19,7 +19,7 @@ var revokeApiTokensCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/auth_revokeapitokens.go
+++ b/internal/cmd/auth_revokeapitokens.go
@@ -19,7 +19,7 @@ var revokeApiTokensCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -64,7 +64,7 @@ var configSetTokenCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		settings, err := settings.ReadSettings()
+		config, err := settings.ReadSettings()
 		if err != nil {
 			return fmt.Errorf("failed to read settings: %w", err)
 		}
@@ -74,7 +74,10 @@ var configSetTokenCmd = &cobra.Command{
 			return fmt.Errorf("invalid token")
 		}
 
-		settings.SetToken(token)
+		config.SetToken(token)
+		if err := settings.TryToPersistChanges(); err != nil {
+			return fmt.Errorf("%w\nIf the issue persists, set your token to the %s environment variable instead", err, internal.Emph(ENV_ACCESS_TOKEN))
+		}
 		fmt.Println("Token set succesfully.")
 		return nil
 	},

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -12,6 +12,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.AddCommand(configSetCmd)
 	configSetCmd.AddCommand(configSetAutoUpdateCmd)
+	configSetCmd.AddCommand(configSetTokenCmd)
 }
 
 var configCmd = &cobra.Command{
@@ -50,6 +51,31 @@ var configSetAutoUpdateCmd = &cobra.Command{
 		settings.SetLastUpdateCheck(0) // trigger an update
 		fmt.Println("Autoupdate set to", internal.Emph(value))
 
+		return nil
+	},
+}
+
+var configSetTokenCmd = &cobra.Command{
+	Use:   "token <jwt>",
+	Short: "Configure the token used by turso",
+	Args:  cobra.ExactArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		settings, err := settings.ReadSettings()
+		if err != nil {
+			return fmt.Errorf("failed to read settings: %w", err)
+		}
+
+		token := args[0]
+		if !isJwtTokenValid(token) {
+			return fmt.Errorf("invalid token")
+		}
+
+		settings.SetToken(token)
+		fmt.Println("Token set succesfully.")
 		return nil
 	},
 }

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -76,7 +76,7 @@ func getDatabaseNames(client *turso.Client) []string {
 }
 
 func completeInstanceName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -97,25 +97,37 @@ var dbCmd = &cobra.Command{
 
 const ENV_ACCESS_TOKEN = "TURSO_API_TOKEN"
 
-func getAccessToken(warnMultipleAccessTokenSources bool) (string, error) {
-	envToken := os.Getenv(ENV_ACCESS_TOKEN)
+func getAccessToken() (string, error) {
+	token, err := envAccessToken()
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		return token, nil
+	}
+
 	settings, err := settings.ReadSettings()
 	if err != nil {
-		return "", fmt.Errorf("could not read local settings")
+		return "", fmt.Errorf("could not read token from settings file: %w", err)
 	}
-	settingsToken := settings.GetToken()
 
-	if !noMultipleTokenSourcesWarning && envToken != "" && settingsToken != "" && warnMultipleAccessTokenSources {
-		fmt.Printf("Warning: User logged in as %s but %q environment variable is set so proceeding to use it instead\n\n", settings.GetUsername(), ENV_ACCESS_TOKEN)
-	}
-	if envToken != "" {
-		return envToken, nil
-	}
-	if !isJwtTokenValid(settingsToken) {
+	token = settings.GetToken()
+	if !isJwtTokenValid(token) {
 		return "", fmt.Errorf("user not logged in, please login with %s", internal.Emph("turso auth login"))
 	}
 
-	return settingsToken, nil
+	return token, nil
+}
+
+func envAccessToken() (string, error) {
+	token := os.Getenv(ENV_ACCESS_TOKEN)
+	if token == "" {
+		return "", nil
+	}
+	if !isJwtTokenValid(token) {
+		return "", fmt.Errorf("token in %s env var is invalid. Update the env var with a valid value, or unset it to use a token from the configuration file", ENV_ACCESS_TOKEN)
+	}
+	return token, nil
 }
 
 type latMap struct {

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -76,7 +76,7 @@ func getDatabaseNames(client *turso.Client) []string {
 }
 
 func completeInstanceName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -44,7 +44,7 @@ var createCmd = &cobra.Command{
 			return fmt.Errorf("invalid database name: %w", err)
 		}
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -44,7 +44,7 @@ var createCmd = &cobra.Command{
 			return fmt.Errorf("invalid database name: %w", err)
 		}
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -26,7 +26,7 @@ var destroyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -26,7 +26,7 @@ var destroyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -27,7 +27,7 @@ var dbGenerateTokenCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -27,7 +27,7 @@ var dbGenerateTokenCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -95,7 +95,7 @@ var dbInspectCmd = &cobra.Command{
 		}
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -95,7 +95,7 @@ var dbInspectCmd = &cobra.Command{
 		}
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -23,7 +23,7 @@ var dbInvalidateTokensCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -23,7 +23,7 @@ var dbInvalidateTokensCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -19,7 +19,7 @@ var listCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -19,7 +19,7 @@ var listCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -23,7 +23,7 @@ var regionsCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -23,7 +23,7 @@ var regionsCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -27,7 +27,7 @@ var replicateCmd = &cobra.Command{
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: replicateArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -147,7 +147,7 @@ func createInstance(client *turso.Client, database turso.Database, location stri
 }
 
 func replicateArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -27,7 +27,7 @@ var replicateCmd = &cobra.Command{
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: replicateArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -147,7 +147,7 @@ func createInstance(client *turso.Client, database turso.Database, location stri
 }
 
 func replicateArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -82,7 +82,7 @@ var shellCmd = &cobra.Command{
 		// Makes sure localhost URL or self-hosted will work even if not authenticated
 		// to turso. The token code will check for auth
 		if !isURL(nameOrUrl) {
-			client, err := createTursoClientFromAccessToken(true)
+			client, err := createTursoClientFromAccessToken()
 			if err != nil {
 				return fmt.Errorf("could not create turso client: %w", err)
 			}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -82,7 +82,7 @@ var shellCmd = &cobra.Command{
 		// Makes sure localhost URL or self-hosted will work even if not authenticated
 		// to turso. The token code will check for auth
 		if !isURL(nameOrUrl) {
-			client, err := createTursoClientFromAccessToken()
+			client, err := authedTursoClient()
 			if err != nil {
 				return fmt.Errorf("could not create turso client: %w", err)
 			}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -28,7 +28,7 @@ var showCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -28,7 +28,7 @@ var showCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_transfer.go
+++ b/internal/cmd/db_transfer.go
@@ -20,7 +20,7 @@ var dbTransferCmd = &cobra.Command{
 	ValidArgsFunction: dbNameAndOrgArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_transfer.go
+++ b/internal/cmd/db_transfer.go
@@ -20,7 +20,7 @@ var dbTransferCmd = &cobra.Command{
 	ValidArgsFunction: dbNameAndOrgArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -22,7 +22,7 @@ var dbUpdateCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -22,7 +22,7 @@ var dbUpdateCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -34,7 +34,7 @@ var groupsListCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,7 @@ var groupsCreateCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ var unarchiveGroupCmd = &cobra.Command{
 	ValidArgsFunction: groupArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ var groupsDestroyCmd = &cobra.Command{
 	ValidArgsFunction: groupArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -34,7 +34,7 @@ var groupsListCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,7 @@ var groupsCreateCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ var unarchiveGroupCmd = &cobra.Command{
 	ValidArgsFunction: groupArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ var groupsDestroyCmd = &cobra.Command{
 	ValidArgsFunction: groupArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -25,7 +25,7 @@ var groupFlag string
 func addGroupFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&groupFlag, "group", "", "create the database in the specified group")
 	cmd.RegisterFlagCompletionFunc("group", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -25,7 +25,7 @@ var groupFlag string
 func addGroupFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&groupFlag, "group", "", "create the database in the specified group")
 	cmd.RegisterFlagCompletionFunc("group", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client, err := createTursoClientFromAccessToken(false)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -35,7 +35,7 @@ var groupLocationsListCmd = &cobra.Command{
 		}
 
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ var groupLocationAddCmd = &cobra.Command{
 		}
 
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ var groupsLocationsRmCmd = &cobra.Command{
 		}
 
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func locationsAddArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 		return groupArgs(cmd, args, toComplete)
 	}
 
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
@@ -206,7 +206,7 @@ func locationsRmArgs(cmd *cobra.Command, args []string, toComplete string) ([]st
 		return groupArgs(cmd, args, toComplete)
 	}
 
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
@@ -226,7 +226,7 @@ func locationsRmArgs(cmd *cobra.Command, args []string, toComplete string) ([]st
 }
 
 func groupArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/group_locations.go
+++ b/internal/cmd/group_locations.go
@@ -35,7 +35,7 @@ var groupLocationsListCmd = &cobra.Command{
 		}
 
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ var groupLocationAddCmd = &cobra.Command{
 		}
 
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ var groupsLocationsRmCmd = &cobra.Command{
 		}
 
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func locationsAddArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 		return groupArgs(cmd, args, toComplete)
 	}
 
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
@@ -206,7 +206,7 @@ func locationsRmArgs(cmd *cobra.Command, args []string, toComplete string) ([]st
 		return groupArgs(cmd, args, toComplete)
 	}
 
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
@@ -226,7 +226,7 @@ func locationsRmArgs(cmd *cobra.Command, args []string, toComplete string) ([]st
 }
 
 func groupArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -33,7 +33,7 @@ var groupTokensInvalidateCmd = &cobra.Command{
 	ValidArgsFunction: groupArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ var groupCreateTokenCmd = &cobra.Command{
 	ValidArgsFunction: groupArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -33,7 +33,7 @@ var groupTokensInvalidateCmd = &cobra.Command{
 	ValidArgsFunction: groupArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ var groupCreateTokenCmd = &cobra.Command{
 	ValidArgsFunction: groupArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/group_transfer.go
+++ b/internal/cmd/group_transfer.go
@@ -22,7 +22,7 @@ var groupTransferCmd = &cobra.Command{
 	ValidArgsFunction: groupTransferArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func groupTransferArgs(cmd *cobra.Command, args []string, toComplete string) ([]
 }
 
 func organizationArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/group_transfer.go
+++ b/internal/cmd/group_transfer.go
@@ -22,7 +22,7 @@ var groupTransferCmd = &cobra.Command{
 	ValidArgsFunction: groupTransferArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func groupTransferArgs(cmd *cobra.Command, args []string, toComplete string) ([]
 }
 
 func organizationArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/group_update.go
+++ b/internal/cmd/group_update.go
@@ -24,7 +24,7 @@ var groupUpdateCmd = &cobra.Command{
 	ValidArgsFunction: groupArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func groupArg(cmd *cobra.Command, args []string, toComplete string) ([]string, c
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
 
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/group_update.go
+++ b/internal/cmd/group_update.go
@@ -24,7 +24,7 @@ var groupUpdateCmd = &cobra.Command{
 	ValidArgsFunction: groupArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func groupArg(cmd *cobra.Command, args []string, toComplete string) ([]string, c
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
 
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/location_flag.go
+++ b/internal/cmd/location_flag.go
@@ -10,7 +10,7 @@ var locationFlag string
 func addLocationFlag(cmd *cobra.Command, desc string) {
 	cmd.Flags().StringVar(&locationFlag, "location", "", desc)
 	cmd.RegisterFlagCompletionFunc("location", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/location_flag.go
+++ b/internal/cmd/location_flag.go
@@ -10,7 +10,7 @@ var locationFlag string
 func addLocationFlag(cmd *cobra.Command, desc string) {
 	cmd.Flags().StringVar(&locationFlag, "location", "", desc)
 	cmd.RegisterFlagCompletionFunc("location", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client, err := createTursoClientFromAccessToken(false)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -90,7 +90,7 @@ var orgListCmd = &cobra.Command{
 			return err
 		}
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ var orgCreateCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		name := args[0]
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ var orgCreateCmd = &cobra.Command{
 		fmt.Printf("\nCreated organization %s.\n", internal.Emph(org.Name))
 		switchToOrg(client, org.Name)
 		fmt.Println()
-		client, err = createTursoClientFromAccessToken(true)
+		client, err = createTursoClientFromAccessToken()
 		if err != nil {
 			client.Organizations.Delete(org.Slug)
 			return err
@@ -196,7 +196,7 @@ var orgDestroyCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		slug := args[0]
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -228,7 +228,7 @@ var orgSwitchCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		slug := args[0]
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -287,7 +287,7 @@ var membersListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -330,7 +330,7 @@ var membersAddCmd = &cobra.Command{
 			return fmt.Errorf("username cannot be empty")
 		}
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -373,7 +373,7 @@ var membersInviteCmd = &cobra.Command{
 			return fmt.Errorf("email cannot be empty")
 		}
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -416,7 +416,7 @@ var membersRemoveCmd = &cobra.Command{
 			return fmt.Errorf("username cannot be empty")
 		}
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -437,7 +437,7 @@ var orgBillingCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -90,7 +90,7 @@ var orgListCmd = &cobra.Command{
 			return err
 		}
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ var orgCreateCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		name := args[0]
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ var orgCreateCmd = &cobra.Command{
 		fmt.Printf("\nCreated organization %s.\n", internal.Emph(org.Name))
 		switchToOrg(client, org.Name)
 		fmt.Println()
-		client, err = createTursoClientFromAccessToken()
+		client, err = authedTursoClient()
 		if err != nil {
 			client.Organizations.Delete(org.Slug)
 			return err
@@ -196,7 +196,7 @@ var orgDestroyCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		slug := args[0]
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -228,7 +228,7 @@ var orgSwitchCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		slug := args[0]
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -287,7 +287,7 @@ var membersListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -330,7 +330,7 @@ var membersAddCmd = &cobra.Command{
 			return fmt.Errorf("username cannot be empty")
 		}
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -373,7 +373,7 @@ var membersInviteCmd = &cobra.Command{
 			return fmt.Errorf("email cannot be empty")
 		}
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -416,7 +416,7 @@ var membersRemoveCmd = &cobra.Command{
 			return fmt.Errorf("username cannot be empty")
 		}
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -437,7 +437,7 @@ var orgBillingCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -61,7 +61,7 @@ var planShowCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ var planSelectCmd = &cobra.Command{
 	Short: "Change your current organization plan",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ var planUpgradeCmd = &cobra.Command{
 	Short: "Upgrade your current organization plan",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ var planEnableOverages = &cobra.Command{
 		if org = settings.Organization(); org == "" {
 			org = settings.GetUsername()
 		}
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}
@@ -279,7 +279,7 @@ var planDisableOverages = &cobra.Command{
 		if org = settings.Organization(); org == "" {
 			org = settings.GetUsername()
 		}
-		client, err := createTursoClientFromAccessToken()
+		client, err := authedTursoClient()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -61,7 +61,7 @@ var planShowCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ var planSelectCmd = &cobra.Command{
 	Short: "Change your current organization plan",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ var planUpgradeCmd = &cobra.Command{
 	Short: "Upgrade your current organization plan",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ var planEnableOverages = &cobra.Command{
 		if org = settings.Organization(); org == "" {
 			org = settings.GetUsername()
 		}
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}
@@ -279,7 +279,7 @@ var planDisableOverages = &cobra.Command{
 		if org = settings.Organization(); org == "" {
 			org = settings.GetUsername()
 		}
-		client, err := createTursoClientFromAccessToken(true)
+		client, err := createTursoClientFromAccessToken()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -25,7 +25,7 @@ const (
 	tursoDefaultBaseURL = "https://api.turso.tech"
 )
 
-func createTursoClientFromAccessToken(warnMultipleAccessTokenSources bool) (*turso.Client, error) {
+func createTursoClientFromAccessToken() (*turso.Client, error) {
 	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func promptConfirmation(prompt string) (bool, error) {
 }
 
 func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -295,7 +295,7 @@ func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 }
 
 func dbNameAndOrgArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken(false)
+	client, err := createTursoClientFromAccessToken()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -26,7 +26,7 @@ const (
 )
 
 func createTursoClientFromAccessToken(warnMultipleAccessTokenSources bool) (*turso.Client, error) {
-	token, err := getAccessToken(warnMultipleAccessTokenSources)
+	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -46,7 +46,7 @@ func tursoClient(token string) (*turso.Client, error) {
 
 	config, err := settings.ReadSettings()
 	if err != nil {
-		return nil, fmt.Errorf("error creating turso client: could not parse turso URL %s: %w", urlStr, err)
+		return nil, fmt.Errorf("error creating turso client: could not read settings file: %w", err)
 	}
 
 	org := config.Organization()

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -25,7 +25,7 @@ const (
 	tursoDefaultBaseURL = "https://api.turso.tech"
 )
 
-func createTursoClientFromAccessToken() (*turso.Client, error) {
+func authedTursoClient() (*turso.Client, error) {
 	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func createTursoClientFromAccessToken() (*turso.Client, error) {
 	return tursoClient(token)
 }
 
-func createUnauthenticatedTursoClient() (*turso.Client, error) {
+func unauthedTursoClient() (*turso.Client, error) {
 	return tursoClient("")
 }
 
@@ -284,7 +284,7 @@ func promptConfirmation(prompt string) (bool, error) {
 }
 
 func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -295,7 +295,7 @@ func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 }
 
 func dbNameAndOrgArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClientFromAccessToken()
+	client, err := authedTursoClient()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
@@ -307,7 +307,7 @@ func dbNameAndOrgArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 }
 
 func fetchLatestVersion() (string, error) {
-	client, err := createUnauthenticatedTursoClient()
+	client, err := unauthedTursoClient()
 	if err != nil {
 		return "", err
 	}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -84,9 +84,16 @@ func PersistChanges() {
 		return
 	}
 
-	if err := viper.WriteConfig(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error persisting turso settings file: ", err.Error())
+	if err := TryToPersistChanges(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
+}
+
+func TryToPersistChanges() error {
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("failed to persist turso settings file: %w", err)
+	}
+	return nil
 }
 
 func (s *Settings) RegisterUse(cmd string) bool {


### PR DESCRIPTION
A few users have asked for help recently with CLI login flow and the warning messages when `TURSO_API_TOKEN` is set.

---

I suggest we make some changes in how it works.

`TURSO_API_TOKEN` env var should still take precedence over the token set in the config file.
But, when the env var is set:
- There will be no warnings on the CLI.
- `turso auth <login|logout|signup>` commands won't work with a clear error message.
- We don't tell users to `export TURSO_API_TOKEN=...` in docs, login flow pages, etc.
- We tell users to use `turso config set token <jwt>` to complete the headless flow. 

---

This PR implements those suggestions, adding `turso config set token` cmd and cleaning up token warning logic.