### PR TITLE
Simplify auth (login and signup) function

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -34,6 +34,7 @@ func init() {
 		fmt.Fprintf(os.Stderr, "error binding token flag: %s", err)
 	}
 	rootCmd.PersistentFlags().BoolVar(&noMultipleTokenSourcesWarning, "no-multiple-token-sources-warning", false, "Don't warn about multiple access token sources")
+	rootCmd.PersistentFlags().MarkHidden("no-multiple-token-sources-warning")
 
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
 		configSettings, err := settings.ReadSettings()


### PR DESCRIPTION
- Extract logic chunk into smaller functinos/structs
- Make it linear, using early returns
- Remove update logic, since we have autoupdate now
- Suggest headless flag when callback server or opening auth URL fail