### PR TITLE
feat(cmd/quickstart): open flag

### DIFF
--- a/internal/cmd/quickstart.go
+++ b/internal/cmd/quickstart.go
@@ -7,8 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var openBrowser bool
+
 func init() {
 	rootCmd.AddCommand(quickstartCmd)
+	quickstartCmd.Flags().BoolVarP(&openBrowser, "open", "o", false, "Open the quickstart guide in the browser.")
 }
 
 var quickstartCmd = &cobra.Command{
@@ -23,12 +26,18 @@ var quickstartCmd = &cobra.Command{
 
 		quickstartURL := "https://docs.turso.tech/quickstart"
 
-		if err := browser.OpenURL(quickstartURL); err != nil {
-			fmt.Printf("To get started with Turso, open the following URL in your browser:\n\n")
-			fmt.Println(quickstartURL)
+		if openBrowser {
+			if err := browser.OpenURL(quickstartURL); err != nil {
+				fmt.Printf("To get started with Turso, open the following URL in your browser:\n")
+				fmt.Println(quickstartURL)
+			} else {
+				fmt.Println("Opening Turso Quickstart Guide in your browser...")
+			}
 		} else {
-			fmt.Println("Opening Turso Quickstart Guide in your browser...")
+			fmt.Printf("To get started with Turso, open the following URL in your browser:\n")
+			fmt.Println(quickstartURL)
 		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
Fixes #787

`turso quickstart` will also prompt users to open the URL to get started instead of opening automatically. Now users are prompted to pass `-o` or `--open` when running `turso quickstart`.