### PR TITLE
Invalidate all user sessions during logout if the -a flag is used

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -354,25 +354,34 @@ func logout(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if flags.All() {
-		turso, err := authedTursoClient()
-		if err != nil {
-			return err
-		}
-
-		from, err := turso.Tokens.Invalidate()
-		if err != nil {
-			return err
-		}
-
-		formatted := time.Unix(from, 0).UTC().Format(time.DateTime)
-		fmt.Printf("Invalidated all sessions started before %s UTC.\n", formatted)
+	if err := invalidateSessionsIfRequested(); err != nil {
+		return err
 	}
 
 	settings.SetToken("")
 	settings.SetUsername("")
 	fmt.Println("Logged out.")
 
+	return nil
+}
+
+func invalidateSessionsIfRequested() error {
+	if !flags.All() {
+		return nil
+	}
+
+	turso, err := authedTursoClient()
+	if err != nil {
+		return err
+	}
+
+	from, err := turso.Tokens.Invalidate()
+	if err != nil {
+		return err
+	}
+
+	formatted := time.Unix(from, 0).UTC().Format(time.DateTime)
+	fmt.Printf("Invalidated all sessions started before %s UTC.\n", formatted)
 	return nil
 }
 

--- a/internal/flags/all.go
+++ b/internal/flags/all.go
@@ -1,0 +1,15 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var all bool
+
+func AddAll(cmd *cobra.Command, usage string) {
+	cmd.Flags().BoolVarP(&all, "all", "a", false, usage)
+}
+
+func All() bool {
+	return all
+}

--- a/internal/turso/token.go
+++ b/internal/turso/token.go
@@ -25,3 +25,22 @@ func (c *TokensClient) Validate(token string) (int64, error) {
 
 	return data.Exp, nil
 }
+
+func (c *TokensClient) Invalidate() (int64, error) {
+	r, err := c.client.Post("/v1/auth/invalidate", nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to request invalidation: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("failed to invalidate sessions: %w", parseResponseError(r))
+	}
+
+	data, err := unmarshal[struct{ ValidFrom int64 }](r)
+	if err != nil {
+		return 0, fmt.Errorf("failed to deserialize invalidate sessions response: %w", err)
+	}
+
+	return data.ValidFrom, nil
+}


### PR DESCRIPTION
```
> turso auth logout --help
Log out currently logged in user.

Usage:
  turso auth logout [flags]

Flags:
  -a, --all    Invalidate all sessions for the current user.
  -h, --help   help for logout

Global Flags:
  -c, --config-path string   Path to the directory with config file
  ```
  

--- 
Example:

```
> turso auth logout -a
Invalidated all sessions started before 2024-02-05 15:08:11 UTC.
Logged out.
```