### PR TITLE
Improve brew post install hook and auto update trigger

### DIFF
--- a/.goreleaser-legacy-tap.yaml
+++ b/.goreleaser-legacy-tap.yaml
@@ -63,7 +63,7 @@ brews:
       zsh_completion.install "completions/turso.zsh" => "_turso"
       fish_completion.install "completions/turso.fish"
     post_install: |
-      exec('turso quickstart')
+      exec('turso post-install')
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ brews:
       zsh_completion.install "completions/turso.zsh" => "_turso"
       fish_completion.install "completions/turso.fish"
     post_install: |
-      exec('turso quickstart')
+      exec('turso post-install')
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.19
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect

--- a/internal/cmd/quickstart.go
+++ b/internal/cmd/quickstart.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"github.com/tursodatabase/turso-cli/internal/settings"
 )
 
 func init() {
 	rootCmd.AddCommand(quickstartCmd)
+	rootCmd.AddCommand(postInstallCmd)
 }
 
 var quickstartCmd = &cobra.Command{
@@ -18,17 +20,43 @@ var quickstartCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		fmt.Print("\nWelcome to Turso!\n\n")
-
-		quickstartURL := "https://docs.turso.tech/quickstart"
-
-		if err := browser.OpenURL(quickstartURL); err != nil {
-			fmt.Printf("To get started with Turso, open the following URL in your browser:\n\n")
-			fmt.Println(quickstartURL)
-		} else {
-			fmt.Println("Opening Turso Quickstart Guide in your browser...")
-		}
+		quickstart(false)
 		return nil
 	},
+}
+
+var postInstallCmd = &cobra.Command{
+	Use:    "post-install",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		if checkSignedIn() {
+			return nil
+		}
+		quickstart(true)
+		return nil
+	},
+}
+
+func quickstart(headless bool) {
+	fmt.Print("\nWelcome to Turso!\n\n")
+
+	quickstartURL := "https://docs.turso.tech/quickstart"
+	if headless || browser.OpenURL(quickstartURL) != nil {
+		fmt.Printf("To get started with Turso, open the following URL in your browser:\n\n")
+		fmt.Println(quickstartURL)
+		return
+	}
+
+	fmt.Println("Opening Turso Quickstart Guide in your browser...")
+}
+
+func checkSignedIn() bool {
+	settings, err := settings.ReadSettings()
+	if err != nil {
+		return false
+	}
+
+	return isJwtTokenValid(settings.GetToken())
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -44,6 +44,10 @@ func init() {
 		}
 		settings.PersistChanges()
 
+		if !isInteractive() {
+			return
+		}
+
 		if version == "dev" {
 			return
 		}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/olekukonko/tablewriter"
@@ -354,4 +355,12 @@ func instancesAndUsage(client *turso.Client, database string) (instances []turso
 	})
 	err = g.Wait()
 	return
+}
+
+func isInteractive() bool {
+	return isTerminal(os.Stdin) && isTerminal(os.Stdout)
+}
+
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }


### PR DESCRIPTION
An attempt at fixing https://github.com/tursodatabase/turso-cli/issues/787.
Replaces https://github.com/tursodatabase/turso-cli/pull/789.

---

This creates a hidden `post-install` command that should only be called by `brew` and `install.sh`.
The new cmd:
- Checks if the user is logged in and, if so, exists.
- Runs quickstart in headless mode, IOW, telling the user to open the browser - not doing it for them.

---

It also prevents the auto-update from running in non-interactive situations, like when using UNIX pipes, triggering autocompletion, etc.  