### PR TITLE
Cache & CLI configuration improvements

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -13,6 +13,9 @@ func init() {
 	configCmd.AddCommand(configSetCmd)
 	configSetCmd.AddCommand(configSetAutoUpdateCmd)
 	configSetCmd.AddCommand(configSetTokenCmd)
+
+	configCmd.AddCommand(configCacheCmd)
+	configCacheCmd.AddCommand(configCacheClearCmd)
 }
 
 var configCmd = &cobra.Command{
@@ -79,6 +82,25 @@ var configSetTokenCmd = &cobra.Command{
 			return fmt.Errorf("%w\nIf the issue persists, set your token to the %s environment variable instead", err, internal.Emph(ENV_ACCESS_TOKEN))
 		}
 		fmt.Println("Token set succesfully.")
+		return nil
+	},
+}
+
+var configCacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "Manage your CLI cache",
+}
+
+var configCacheClearCmd = &cobra.Command{
+	Use:               "clear",
+	Short:             "Clear your CLI local cache",
+	Args:              cobra.ExactArgs(0),
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := settings.ClearCache(); err != nil {
+			return fmt.Errorf("failed to clear cache: %w", err)
+		}
+		fmt.Println("Local cache cleared successfully")
 		return nil
 	},
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -10,6 +10,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configPathCmd)
 	configCmd.AddCommand(configSetCmd)
 	configSetCmd.AddCommand(configSetAutoUpdateCmd)
 	configSetCmd.AddCommand(configSetTokenCmd)
@@ -101,6 +102,18 @@ var configCacheClearCmd = &cobra.Command{
 			return fmt.Errorf("failed to clear cache: %w", err)
 		}
 		fmt.Println("Local cache cleared successfully")
+		return nil
+	},
+}
+
+var configPathCmd = &cobra.Command{
+	Use:               "path",
+	Short:             "Get the path to the CLI configuration file",
+	Args:              cobra.ExactArgs(0),
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, _ = settings.ReadSettings()
+		fmt.Println(settings.Path())
 		return nil
 	},
 }

--- a/internal/settings/cache.go
+++ b/internal/settings/cache.go
@@ -29,6 +29,15 @@ func SetCacheRaw[T any](key string, value T) error {
 	return nil
 }
 
+func ClearCache() error {
+	if _, err := ReadSettings(); err != nil {
+		return err
+	}
+	viper.Set("cache", struct{}{})
+	settings.changed = true
+	return nil
+}
+
 func SetCache[T any](key string, ttl int64, value T) error {
 	exp := time.Now().Unix() + ttl
 	return SetCacheWithExp(key, exp, value)

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -79,6 +79,10 @@ func ReadSettings() (*Settings, error) {
 	return settings, nil
 }
 
+func Path() string {
+	return viper.ConfigFileUsed()
+}
+
 func PersistChanges() {
 	if settings == nil || !settings.changed {
 		return


### PR DESCRIPTION
General utilities for users to interact with local config and local cache.
Also clears the database tokens cache in case of errors. Useful for handling errors like [this one](https://discord.com/channels/933071162680958986/933071163184283651/1204196960542789673).