### PR TITLE
Increase shell token life to 2d and reduce cache to 6 hours

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -258,12 +258,12 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 		return token, nil
 	}
 
-	token, err := client.Databases.Token(db.Name, "1d", false)
+	token, err := client.Databases.Token(db.Name, "2d", false)
 	if err != nil {
 		return "", err
 	}
 
-	exp := time.Now().Add(time.Hour * 23).Unix()
+	exp := time.Now().Add(time.Hour * 6).Unix()
 	setDbTokenCache(db.ID, token, exp)
 
 	return token, nil


### PR DESCRIPTION
We're seeing some users getting expired token errors. It happens when their system time has drifted from real time. This usually happens when people use dual boot and are not on UTC.

This should be enough to prevent up to 42 hours of clock drift.