### PR TITLE
Use the granular permissions in token APIs

### DIFF
--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -59,5 +59,5 @@ func getToken(client *turso.Client, database turso.Database, expiration string, 
 	if group && database.Group == "" {
 		return "", fmt.Errorf("--group flag can only be set with group databases")
 	}
-	return client.Groups.Token(database.Group, expiration, readOnly)
+	return client.Groups.Token(database.Group, expiration, readOnly, nil)
 }

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -17,7 +17,7 @@ func init() {
 
 	flags.AddExpiration(dbGenerateTokenCmd)
 	flags.AddReadOnly(dbGenerateTokenCmd)
-	flags.AddAttachClaim(dbGenerateTokenCmd)
+	flags.AddAttachClaims(dbGenerateTokenCmd)
 	dbGenerateTokenCmd.Flags().BoolVar(&groupTokenFlag, "group", false, "create a token that is valid for all databases in the group")
 }
 
@@ -45,13 +45,13 @@ var dbGenerateTokenCmd = &cobra.Command{
 		}
 
 		var claim *turso.PermissionsClaim
-		if len(flags.AttachClaim()) > 0 {
-			dbNames, err := validateDBNames(flags.AttachClaim())
+		if len(flags.AttachClaims()) > 0 {
+			err := validateDBNames(flags.AttachClaims())
 			if err != nil {
 				return err
 			}
 			claim = &turso.PermissionsClaim{
-				ReadAttach: turso.Entities{DBNames: dbNames},
+				ReadAttach: turso.Entities{DBNames: flags.AttachClaims()},
 			}
 		}
 		token, err := getToken(client, database, expiration, flags.ReadOnly(), groupTokenFlag, claim)

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -17,6 +17,7 @@ func init() {
 
 	flags.AddExpiration(dbGenerateTokenCmd)
 	flags.AddReadOnly(dbGenerateTokenCmd)
+	flags.AddAttachClaim(dbGenerateTokenCmd)
 	dbGenerateTokenCmd.Flags().BoolVar(&groupTokenFlag, "group", false, "create a token that is valid for all databases in the group")
 }
 
@@ -43,7 +44,17 @@ var dbGenerateTokenCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := getToken(client, database, expiration, flags.ReadOnly(), groupTokenFlag)
+		var claim *turso.PermissionsClaim
+		if len(flags.AttachClaim()) > 0 {
+			dbNames, err := validateDBNames(flags.AttachClaim())
+			if err != nil {
+				return err
+			}
+			claim = &turso.PermissionsClaim{
+				ReadAttach: turso.Entities{DBNames: dbNames},
+			}
+		}
+		token, err := getToken(client, database, expiration, flags.ReadOnly(), groupTokenFlag, claim)
 		if err != nil {
 			return fmt.Errorf("your database does not support token generation")
 		}
@@ -52,12 +63,12 @@ var dbGenerateTokenCmd = &cobra.Command{
 	},
 }
 
-func getToken(client *turso.Client, database turso.Database, expiration string, readOnly, group bool) (string, error) {
+func getToken(client *turso.Client, database turso.Database, expiration string, readOnly, group bool, claim *turso.PermissionsClaim) (string, error) {
 	if !group {
-		return client.Databases.Token(database.Name, expiration, readOnly)
+		return client.Databases.Token(database.Name, expiration, readOnly, claim)
 	}
 	if group && database.Group == "" {
 		return "", fmt.Errorf("--group flag can only be set with group databases")
 	}
-	return client.Groups.Token(database.Group, expiration, readOnly, nil)
+	return client.Groups.Token(database.Group, expiration, readOnly, claim)
 }

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -261,7 +261,7 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 		return token, nil
 	}
 
-	token, err := client.Databases.Token(db.Name, "2d", false)
+	token, err := client.Databases.Token(db.Name, "2d", false, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -131,7 +131,7 @@ var groupCreateTokenCmd = &cobra.Command{
 	},
 }
 
-func validateDBNames(dbNames []string) ([]string, error) {
+func validateDBNames(dbNames []string) error {
 	databases := map[string]string{}
 	for _, db := range getDatabasesCache() {
 		databases[db.Name] = db.ID

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -86,7 +86,7 @@ func init() {
 	groupTokensCmd.AddCommand(groupCreateTokenCmd)
 	flags.AddExpiration(groupCreateTokenCmd)
 	flags.AddReadOnly(groupCreateTokenCmd)
-	flags.AddAttachClaim(groupCreateTokenCmd)
+	flags.AddAttachClaims(groupCreateTokenCmd)
 }
 
 var groupCreateTokenCmd = &cobra.Command{
@@ -112,13 +112,13 @@ var groupCreateTokenCmd = &cobra.Command{
 			return err
 		}
 		var claim *turso.PermissionsClaim
-		if len(flags.AttachClaim()) > 0 {
-			dbNames, err := validateDBNames(flags.AttachClaim())
+		if len(flags.AttachClaims()) > 0 {
+			err := validateDBNames(flags.AttachClaims())
 			if err != nil {
 				return err
 			}
 			claim = &turso.PermissionsClaim{
-				ReadAttach: turso.Entities{DBNames: dbNames},
+				ReadAttach: turso.Entities{DBNames: flags.AttachClaims()},
 			}
 		}
 		token, err := client.Groups.Token(group.Name, expiration, flags.ReadOnly(), claim)
@@ -136,12 +136,10 @@ func validateDBNames(dbNames []string) error {
 	for _, db := range getDatabasesCache() {
 		databases[db.Name] = db.ID
 	}
-	var validDBNames []string
 	for _, name := range dbNames {
 		if _, ok := databases[name]; !ok {
-			return nil, fmt.Errorf("database %s does not exist", name)
+			return fmt.Errorf("database %s does not exist", name)
 		}
-		validDBNames = append(validDBNames, name)
 	}
-	return validDBNames, nil
+	return nil
 }

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -86,6 +86,7 @@ func init() {
 	groupTokensCmd.AddCommand(groupCreateTokenCmd)
 	flags.AddExpiration(groupCreateTokenCmd)
 	flags.AddReadOnly(groupCreateTokenCmd)
+	flags.AddClaim(groupCreateTokenCmd)
 }
 
 var groupCreateTokenCmd = &cobra.Command{
@@ -110,8 +111,17 @@ var groupCreateTokenCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		token, err := client.Groups.Token(group.Name, expiration, flags.ReadOnly())
+		var claim *turso.PermissionsClaim
+		if len(flags.Claim()) > 0 {
+			namespaces, err := validateDBNames(flags.Claim())
+			if err != nil {
+				return err
+			}
+			claim = &turso.PermissionsClaim{
+				ReadAttach: turso.Entities{Namespaces: namespaces},
+			}
+		}
+		token, err := client.Groups.Token(group.Name, expiration, flags.ReadOnly(), claim)
 		if err != nil {
 			return fmt.Errorf("error creating token: %w", err)
 		}
@@ -119,4 +129,19 @@ var groupCreateTokenCmd = &cobra.Command{
 		fmt.Println(token)
 		return nil
 	},
+}
+
+func validateDBNames(dbNames []string) ([]string, error) {
+	databases := map[string]string{}
+	for _, db := range getDatabasesCache() {
+		databases[db.Name] = db.ID
+	}
+	var validNamespaces []string
+	for _, name := range dbNames {
+		if _, ok := databases[name]; !ok {
+			return nil, fmt.Errorf("database %s does not exist", name)
+		}
+		validNamespaces = append(validNamespaces, databases[name])
+	}
+	return validNamespaces, nil
 }

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -86,7 +86,7 @@ func init() {
 	groupTokensCmd.AddCommand(groupCreateTokenCmd)
 	flags.AddExpiration(groupCreateTokenCmd)
 	flags.AddReadOnly(groupCreateTokenCmd)
-	flags.AddClaim(groupCreateTokenCmd)
+	flags.AddAttachClaim(groupCreateTokenCmd)
 }
 
 var groupCreateTokenCmd = &cobra.Command{
@@ -112,13 +112,13 @@ var groupCreateTokenCmd = &cobra.Command{
 			return err
 		}
 		var claim *turso.PermissionsClaim
-		if len(flags.Claim()) > 0 {
-			namespaces, err := validateDBNames(flags.Claim())
+		if len(flags.AttachClaim()) > 0 {
+			dbNames, err := validateDBNames(flags.AttachClaim())
 			if err != nil {
 				return err
 			}
 			claim = &turso.PermissionsClaim{
-				ReadAttach: turso.Entities{Namespaces: namespaces},
+				ReadAttach: turso.Entities{DBNames: dbNames},
 			}
 		}
 		token, err := client.Groups.Token(group.Name, expiration, flags.ReadOnly(), claim)
@@ -136,12 +136,12 @@ func validateDBNames(dbNames []string) ([]string, error) {
 	for _, db := range getDatabasesCache() {
 		databases[db.Name] = db.ID
 	}
-	var validNamespaces []string
+	var validDBNames []string
 	for _, name := range dbNames {
 		if _, ok := databases[name]; !ok {
 			return nil, fmt.Errorf("database %s does not exist", name)
 		}
-		validNamespaces = append(validNamespaces, databases[name])
+		validDBNames = append(validDBNames, name)
 	}
-	return validNamespaces, nil
+	return validDBNames, nil
 }

--- a/internal/flags/claim.go
+++ b/internal/flags/claim.go
@@ -2,12 +2,12 @@ package flags
 
 import "github.com/spf13/cobra"
 
-var claimFlag []string
+var attachFlag []string
 
-func AddClaim(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&claimFlag, "claim", nil, "list of database claims to be added to the token")
+func AddAttachClaim(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&attachFlag, "attach", nil, "list of database names with attach claim to be added to the token")
 }
 
-func Claim() []string {
-	return claimFlag
+func AttachClaim() []string {
+	return attachFlag
 }

--- a/internal/flags/claim.go
+++ b/internal/flags/claim.go
@@ -8,6 +8,6 @@ func AddAttachClaims(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&attachFlag, "attach", nil, "list of database names with attach claim to be added to the token")
 }
 
-func AttachClaim() []string {
+func AttachClaims() []string {
 	return attachFlag
 }

--- a/internal/flags/claim.go
+++ b/internal/flags/claim.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var attachFlag []string
 
-func AddAttachClaim(cmd *cobra.Command) {
+func AddAttachClaims(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&attachFlag, "attach", nil, "list of database names with attach claim to be added to the token")
 }
 

--- a/internal/flags/claim.go
+++ b/internal/flags/claim.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 var claimFlag []string
 
 func AddClaim(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&claimFlag, "claim", nil, "Custom claims in JSON format")
+	cmd.Flags().StringSliceVar(&claimFlag, "claim", nil, "list of database claims to be added to the token")
 }
 
 func Claim() []string {

--- a/internal/flags/claim.go
+++ b/internal/flags/claim.go
@@ -1,0 +1,13 @@
+package flags
+
+import "github.com/spf13/cobra"
+
+var claimFlag []string
+
+func AddClaim(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&claimFlag, "claim", nil, "Custom claims in JSON format")
+}
+
+func Claim() []string {
+	return claimFlag
+}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -175,13 +175,24 @@ func (d *DatabasesClient) UploadDump(dbFile *os.File) (string, error) {
 	return data.DumpURL, nil
 }
 
-func (d *DatabasesClient) Token(database string, expiration string, readOnly bool) (string, error) {
+type DatabaseTokenRequest struct {
+	Permissions *PermissionsClaim `json:"permissions,omitempty"`
+}
+
+func (d *DatabasesClient) Token(database string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
 	authorization := ""
 	if readOnly {
 		authorization = "&authorization=read-only"
 	}
 	url := d.URL(fmt.Sprintf("/%s/auth/tokens?expiration=%s%s", database, expiration, authorization))
-	r, err := d.client.Post(url, nil)
+
+	req := DatabaseTokenRequest{permissions}
+	body, err := marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	r, err := d.client.Post(url, body)
 	if err != nil {
 		return "", fmt.Errorf("failed to get database token: %w", err)
 	}

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -2,7 +2,6 @@ package turso
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/tursodatabase/turso-cli/internal"
@@ -192,14 +191,14 @@ func (d *GroupsClient) WaitLocation(name, location string) error {
 }
 
 type Entities struct {
-	Namespaces []string `json:"namespaces,omitempty"`
+	DBNames []string `json:"databases,omitempty"`
 }
 
 type PermissionsClaim struct {
 	ReadAttach Entities `json:"read_attach,omitempty"`
 }
 
-type TokenRequest struct {
+type GroupTokenRequest struct {
 	Permissions *PermissionsClaim `json:"permissions,omitempty"`
 }
 
@@ -210,14 +209,10 @@ func (d *GroupsClient) Token(group string, expiration string, readOnly bool, per
 	}
 	url := d.URL(fmt.Sprintf("/%s/auth/tokens?expiration=%s%s", group, expiration, authorization))
 
-	var body io.Reader
-	if permissions != nil {
-		req := TokenRequest{permissions}
-		b, err := marshal(req)
-		if err != nil {
-			return "", fmt.Errorf("could not serialize request body: %w", err)
-		}
-		body = b
+	req := GroupTokenRequest{permissions}
+	body, err := marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize request body: %w", err)
 	}
 
 	r, err := d.client.Post(url, body)


### PR DESCRIPTION
e.g usage:

```sh
turso group tokens create momos --attach awake-speedball,blessed-silver-sable,super-valkyrie
```

or 

```sh
turso group tokens create momos --attach awake-speedball --attach blessed-silver-sable --attach super-valkyrie
```

For db tokens:

```sh
turso db tokens create awake-speedball --attach blessed-silver-sable --attach super-valkyrie
```