### PR TITLE
Use persistent connection for shell

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -39,10 +39,10 @@ func getURL(db *turso.Database, client *turso.Client) (string, error) {
 		}
 		for _, instance := range instances {
 			if instance.Region == locationFlag {
-				return getInstanceHttpUrl(db, &instance), nil
+				return getInstanceWSUrl(db, &instance), nil
 			}
 			if instance.Name == instanceFlag {
-				return getInstanceHttpUrl(db, &instance), nil
+				return getInstanceWSUrl(db, &instance), nil
 			}
 		}
 		if locationFlag != "" {
@@ -53,7 +53,7 @@ func getURL(db *turso.Database, client *turso.Client) (string, error) {
 		}
 		return "", fmt.Errorf("impossible")
 	} else {
-		return getDatabaseHttpUrl(db), nil
+		return getDatabaseWSUrl(db), nil
 	}
 }
 

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -92,10 +92,6 @@ func getDatabaseWSUrl(db *turso.Database) string {
 	return getUrl(db, nil, "wss")
 }
 
-func getInstanceHttpUrl(db *turso.Database, inst *turso.Instance) string {
-	return getUrl(db, inst, "https")
-}
-
 func getInstanceWSUrl(db *turso.Database, inst *turso.Instance) string {
 	return getUrl(db, inst, "wss")
 }

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -88,8 +88,16 @@ func getDatabaseHttpUrl(db *turso.Database) string {
 	return getUrl(db, nil, "https")
 }
 
+func getDatabaseWSUrl(db *turso.Database) string {
+	return getUrl(db, nil, "wss")
+}
+
 func getInstanceHttpUrl(db *turso.Database, inst *turso.Instance) string {
 	return getUrl(db, inst, "https")
+}
+
+func getInstanceWSUrl(db *turso.Database, inst *turso.Instance) string {
+	return getUrl(db, inst, "wss")
 }
 
 func getUrl(db *turso.Database, inst *turso.Instance, scheme string) string {


### PR DESCRIPTION
This patch uses websocket connections instead of
HTTP for the shell. In HTTP mode, we use a connection pool. So, at every invocation in shell, can use a
different connection. While this is okay for most cases, but this doesn't work for operations involving stateful connections viz. transactions, ATTACH statements and a few PRAGMA statements.

closes:
https://github.com/tursodatabase/turso-cli/issues/784 
https://github.com/tursodatabase/libsql-shell-go/issues/163

---

## Before 

```shell
→  PRAGMA foreign_keys=OFF;
→  PRAGMA foreign_keys;
FOREIGN KEYS
1
→
→  BEGIN;
→  SELECT 42;
42
42
→  COMMIT;
Error: failed to execute SQL: COMMIT;
SQLite error: cannot commit - no transaction is active
→
```

## Afterr

```shell
→  PRAGMA foreign_keys=OFF;
→  PRAGMA foreign_keys;
FOREIGN KEYS
0
→  BEGIN;
→  SELECT 42;
42
42
→  COMMIT;
```