### PR TITLE
Add support for `--attach` to shell

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -268,12 +268,16 @@ func tokenFromDb(db *turso.Database, client *turso.Client, claim *turso.Permissi
 	if db == nil {
 		return "", nil
 	}
+	// skip cache and always use token from server when claims are attached
+	if claim != nil {
+		return client.Databases.Token(db.Name, "2d", false, claim)
+	}
 
 	if token := dbTokenCache(db.ID); token != "" {
 		return token, nil
 	}
 
-	token, err := client.Databases.Token(db.Name, "2d", false, claim)
+	token, err := client.Databases.Token(db.Name, "2d", false, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libsql/libsql-shell-go/pkg/shell/enums"
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
+	"github.com/tursodatabase/turso-cli/internal/flags"
 	"github.com/tursodatabase/turso-cli/internal/prompt"
 	"github.com/tursodatabase/turso-cli/internal/settings"
 	"github.com/tursodatabase/turso-cli/internal/turso"
@@ -29,6 +30,7 @@ func init() {
 	shellCmd.RegisterFlagCompletionFunc("proxy", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	})
+	flags.AddAttachClaims(shellCmd)
 }
 
 func getURL(db *turso.Database, client *turso.Client) (string, error) {
@@ -94,11 +96,21 @@ var shellCmd = &cobra.Command{
 				return err
 			}
 
-			authToken, err = tokenFromDb(db, client)
+			var claim *turso.PermissionsClaim
+			if len(flags.AttachClaims()) > 0 {
+				err := validateDBNames(flags.AttachClaims())
+				if err != nil {
+					return err
+				}
+				claim = &turso.PermissionsClaim{
+					ReadAttach: turso.Entities{DBNames: flags.AttachClaims()},
+				}
+			}
+
+			authToken, err = tokenFromDb(db, client, claim)
 			if err != nil {
 				return err
 			}
-
 			dbUrl, err = getURL(db, client)
 			if err != nil {
 				return err
@@ -252,7 +264,7 @@ func isURL(s string) bool {
 	return err == nil
 }
 
-func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
+func tokenFromDb(db *turso.Database, client *turso.Client, claim *turso.PermissionsClaim) (string, error) {
 	if db == nil {
 		return "", nil
 	}
@@ -261,7 +273,7 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 		return token, nil
 	}
 
-	token, err := client.Databases.Token(db.Name, "2d", false, nil)
+	token, err := client.Databases.Token(db.Name, "2d", false, claim)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This a follow up from #799 Example usage:

```shell
turso db shell robust-serpentor --attach master-madame-masque 
```