### PR TITLE
Only print spinner message in non-interactive environments

### DIFF
--- a/internal/prompt/interactive.go
+++ b/internal/prompt/interactive.go
@@ -1,0 +1,13 @@
+package prompt
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+var isInteractive = isTerminal(os.Stdin) && isTerminal(os.Stdout)
+
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}

--- a/internal/prompt/spinner.go
+++ b/internal/prompt/spinner.go
@@ -67,6 +67,11 @@ func (m *spinner) Text(t string) {
 }
 
 func (m *spinner) Start() {
+	if !isInteractive {
+		fmt.Println(m.View())
+		return
+	}
+
 	ch := make(chan bool)
 	m.done = ch
 	m.quitting = false


### PR DESCRIPTION
This should avoid breaking the shell when scripting with our CLI.


---


Tested with:
```
➜  turso-cli git:(main) ✗ turso group create local2 | cat
⣾  Creating group local2 at gru...
Created group local2 at gru in 12.098s.
```