### PR TITLE
Add db config cmd to allow/disallow attach

### DIFF
--- a/internal/cmd/db_attach.go
+++ b/internal/cmd/db_attach.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tursodatabase/turso-cli/internal"
+	"github.com/tursodatabase/turso-cli/internal/turso"
+)
+
+func init() {
+	dbConfigCmd.AddCommand(dbAttachCmd)
+	dbAttachCmd.AddCommand(dbEnableAttachCmd)
+	dbAttachCmd.AddCommand(dbDisableAttachCmd)
+	dbAttachCmd.AddCommand(dbShowAttachStatusCmd)
+}
+
+var dbAttachCmd = &cobra.Command{
+	Use:               "attach",
+	Short:             "Manage attach config of a database",
+	ValidArgsFunction: noSpaceArg,
+}
+
+var dbEnableAttachCmd = &cobra.Command{
+	Use:               "allow <database-name>",
+	Short:             "Allows this database to be attached by other databases",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: dbNameArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return updateAttachStatus(args[0], true)
+	},
+}
+
+var dbDisableAttachCmd = &cobra.Command{
+	Use:               "disallow <database-name>",
+	Short:             "Disallows this database to be attached by other databases",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: dbNameArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return updateAttachStatus(args[0], false)
+	},
+}
+
+var dbShowAttachStatusCmd = &cobra.Command{
+	Use:               "show <database-name>",
+	Short:             "Shows the attach status of a database",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: dbNameArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		client, err := authedTursoClient()
+		if err != nil {
+			return err
+		}
+		name := args[0]
+
+		database, err := getDatabase(client, name, true)
+		if err != nil {
+			return err
+		}
+		config, err := client.Databases.GetConfig(database.Name)
+		if err != nil {
+			return err
+		}
+		fmt.Print(attachMessage(config.AllowAttach))
+		return err
+	},
+}
+
+func updateAttachStatus(name string, allowAttach bool) error {
+	client, err := authedTursoClient()
+	if err != nil {
+		return err
+	}
+	database, err := getDatabase(client, name, true)
+	if err != nil {
+		return err
+	}
+	return client.Databases.UpdateConfig(database.Name, turso.DatabaseConfig{AllowAttach: allowAttach})
+}
+
+func attachMessage(attach bool) string {
+	status := "not allowed"
+	if attach {
+		status = "allowed"
+	}
+	return fmt.Sprintf("Attach %s\n", internal.Emph(status))
+}

--- a/internal/cmd/db_config.go
+++ b/internal/cmd/db_config.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func init() {
+	dbCmd.AddCommand(dbConfigCmd)
+}
+
+var dbConfigCmd = &cobra.Command{
+	Use:               "config",
+	Short:             "Manage db config",
+	ValidArgsFunction: noSpaceArg,
+}


### PR DESCRIPTION
Usage: 

```
$ turso db config attach

Manage attach config of a database

Usage:
  turso db config attach [command]

Available Commands:
  allow       Allows this database to be attached by other databases
  disallow    Disallows this database to be attached by other databases
  show        Shows the attach status of a database

$ turso db config attach show key-spectrum
Attach not allowed

$ turso db config attach allow key-spectrum
$ turso db config attach show key-spectrum
Attach allowed

$ turso db config attach disallow key-spectrum
$ turso db config attach show key-spectrum
Attach not allowed
```