### PR TITLE
bugfix: switch to http for the `.dump`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gdamore/tcell v1.4.0
 	github.com/google/uuid v1.3.0
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
-	github.com/libsql/libsql-shell-go v0.9.3
+	github.com/libsql/libsql-shell-go v0.9.4-0.20240313071646-14620be78fd0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
@@ -26,6 +26,8 @@ require (
 )
 
 require github.com/hashicorp/go-version v1.6.0
+
+require github.com/tursodatabase/libsql-client-go v0.0.0-20231216154754-8383a53d618f // indirect
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9 // indirect
@@ -43,7 +45,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
-	github.com/libsql/libsql-client-go v0.0.0-20231116123136-ff4e46c3d3a1 // indirect
 	github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,10 +240,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
-github.com/libsql/libsql-client-go v0.0.0-20231116123136-ff4e46c3d3a1 h1:wBq6jZyliLZnM4SSvhoeLtlFwQw3mxKIqsUd/JvG6Dk=
-github.com/libsql/libsql-client-go v0.0.0-20231116123136-ff4e46c3d3a1/go.mod h1:T+1lRvREkstNW7bmF1PTiDhV6hji0mrlfZkZuk/UPhw=
-github.com/libsql/libsql-shell-go v0.9.3 h1:GIU43K1ZXWSm8ry+sC+OMTGgL7+E+Pul9gdnQ+/IOzQ=
-github.com/libsql/libsql-shell-go v0.9.3/go.mod h1:3XfgTaSJMjo1Y9XSLml4WzADUhnZp3xIta+TyR+tCxs=
+github.com/libsql/libsql-shell-go v0.9.4-0.20240313071646-14620be78fd0 h1:bhpUPLSa3jKSuoHkd8HR6+oCHdtR398yV7DuQtCjnHg=
+github.com/libsql/libsql-shell-go v0.9.4-0.20240313071646-14620be78fd0/go.mod h1:VBZzPK21wJRzLo5Yf+TO43eoDi9xYjr/zI5SCjfkt98=
 github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475 h1:6PfEMwfInASh9hkN83aR0j4W/eKaAZt/AURtXAXlas0=
 github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475/go.mod h1:20nXSmcf0nAscrzqsXeC2/tA3KkV2eCiJqYuyAgl+ss=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
@@ -343,6 +341,8 @@ github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gt
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/tursodatabase/libsql-client-go v0.0.0-20231216154754-8383a53d618f h1:teZ0Pj1Wp3Wk0JObKBiKZqgxhYwLeJhVAyj6DRgmQtY=
+github.com/tursodatabase/libsql-client-go v0.0.0-20231216154754-8383a53d618f/go.mod h1:UMde0InJz9I0Le/1YIR4xsB0E2vb01MrDY6k/eNdfkg=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -59,6 +59,13 @@ func getURL(db *turso.Database, client *turso.Client) (string, error) {
 	}
 }
 
+func getDbURLForDump(u string) string {
+	if strings.HasPrefix(u, "wss://") || strings.HasPrefix(u, "ws://") {
+		return strings.Replace(u, "ws", "http", 1)
+	}
+	return u
+}
+
 var shellCmd = &cobra.Command{
 	Use:               "shell <database-name | replica-url> [sql]",
 	Short:             "Start a SQL shell.",
@@ -178,7 +185,7 @@ var shellCmd = &cobra.Command{
 				return fmt.Errorf("no SQL command to execute")
 			}
 			if args[1] == ".dump" {
-				return dump(dbUrl, authToken)
+				return dump(getDbURLForDump(dbUrl), authToken)
 			}
 			return runShellLine(dbID, shellConfig, args[1])
 		}


### PR DESCRIPTION
We switched to websockets in #802. However, this introduced a regression since dump endpoint is HTTP. This patch overrides the URL to `http` from `ws` for dump.

depends on https://github.com/tursodatabase/libsql-shell-go/pull/165 

reported on discord: https://discord.com/channels/933071162680958986/1217266254814122127/1217266254814122127