### PR TITLE
feat: show usage information of bytes synced

### DIFF
--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -16,73 +16,6 @@ func init() {
 	addQueriesFlag(dbInspectCmd)
 }
 
-type InspectInstanceInfo struct {
-	Location      string
-	Name          string
-	Type          string
-	StorageInfos  []StorageInfo
-	RowsReadCount uint64
-}
-
-type InspectInfo struct {
-	instanceInfos [](*InspectInstanceInfo)
-}
-
-type StorageInfo struct {
-	Type        string
-	Name        string
-	SizeTables  uint64
-	SizeIndexes uint64
-}
-
-func (curr *InspectInstanceInfo) totalTablesSize() uint64 {
-	var total uint64
-	for _, storageInfo := range curr.StorageInfos {
-		total += storageInfo.SizeTables
-	}
-	return total
-}
-
-func (curr *InspectInstanceInfo) totalIndexesSize() uint64 {
-	var total uint64
-	for _, storageInfo := range curr.StorageInfos {
-		total += storageInfo.SizeIndexes
-	}
-	return total
-}
-
-func (curr *InspectInfo) Accumulate(n *InspectInstanceInfo) {
-	curr.instanceInfos = append(curr.instanceInfos, n)
-}
-
-func (curr *InspectInfo) totalTablesSize() uint64 {
-	var total uint64
-	for _, instanceInfo := range curr.instanceInfos {
-		total += instanceInfo.totalTablesSize()
-	}
-	return total
-}
-
-func (curr *InspectInfo) totalIndexesSize() uint64 {
-	var total uint64
-	for _, instanceInfo := range curr.instanceInfos {
-		total += instanceInfo.totalIndexesSize()
-	}
-	return total
-}
-
-func (curr *InspectInfo) PrintTotalStorage() string {
-	return humanize.Bytes(curr.totalTablesSize() + curr.totalIndexesSize())
-}
-
-func (curr *InspectInfo) TotalRowsReadCount() uint64 {
-	var total uint64
-	for _, instanceInfo := range curr.instanceInfos {
-		total += instanceInfo.RowsReadCount
-	}
-	return total
-}
-
 var dbInspectCmd = &cobra.Command{
 	Use:               "inspect <database-name>",
 	Short:             "Inspect database.",
@@ -118,6 +51,9 @@ var dbInspectCmd = &cobra.Command{
 		fmt.Printf("Total space used: %s\n", humanize.Bytes(dbUsage.Usage.StorageBytesUsed))
 		fmt.Printf("Number of rows read: %d\n", dbUsage.Usage.RowsRead)
 		fmt.Printf("Number of rows written: %d\n", dbUsage.Usage.RowsWritten)
+		if dbUsage.Usage.BytesSynced != 0 {
+			fmt.Printf("Number of bytes synced: %s\n", humanize.Bytes(dbUsage.Usage.BytesSynced))
+		}
 
 		if len(instances) == 0 {
 			fmt.Printf("\n🛠 Run %s to finish your database creation!\n", internal.Emph("turso db replicate "+db.Name))
@@ -129,14 +65,14 @@ var dbInspectCmd = &cobra.Command{
 		}
 
 		instancesUsage := getInstanceUsageMap(dbUsage.Instances)
-		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "ROWS WRITTEN", "TOTAL STORAGE")
+		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "ROWS WRITTEN", "TOTAL STORAGE", "BYTES SYNCED")
 		for _, instance := range instances {
 			usg, ok := instancesUsage[instance.Uuid]
 			if !ok {
 				tbl.AddRow(instance.Region, instance.Type, instance.Name, "-", "-", "-")
 				continue
 			}
-			tbl.AddRow(instance.Region, instance.Type, instance.Name, usg.RowsRead, usg.RowsWritten, humanize.Bytes(usg.StorageBytesUsed))
+			tbl.AddRow(instance.Region, instance.Type, instance.Name, usg.RowsRead, usg.RowsWritten, humanize.Bytes(usg.StorageBytesUsed), humanize.Bytes(usg.BytesSynced))
 		}
 
 		fmt.Println()

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -93,6 +93,8 @@ var showCmd = &cobra.Command{
 		fmt.Println("Locations:     ", strings.Join(regions, ", "))
 		fmt.Println("Size:          ", humanize.Bytes(dbUsage.Usage.StorageBytesUsed))
 		fmt.Println("Sleeping:      ", formatBool(db.Sleeping))
+		fmt.Println("Bytes Synced:  ", humanize.Bytes(dbUsage.Usage.BytesSynced))
+
 		fmt.Println()
 
 		if len(instances) == 0 {

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -133,6 +133,7 @@ func planUsageTable(orgUsage turso.OrgUsage, current turso.Plan, currentOrg turs
 	addResourceRowCount(tbl, "databases", orgUsage.Usage.Databases, current.Quotas.Databases)
 	addResourceRowCount(tbl, "locations", orgUsage.Usage.Locations, current.Quotas.Locations)
 	addResourceRowCount(tbl, "groups", orgUsage.Usage.Groups, current.Quotas.Groups)
+	addResourceRowBytes(tbl, "bytes synced", orgUsage.Usage.BytesSynced, current.Quotas.BytesSynced, currentOrg.Overages)
 	return tbl
 }
 

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -343,6 +343,7 @@ type Usage struct {
 	RowsRead         uint64 `json:"rows_read,omitempty"`
 	RowsWritten      uint64 `json:"rows_written,omitempty"`
 	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
+	BytesSynced      uint64 `json:"bytes_synced,omitempty"`
 }
 
 type InstanceUsage struct {

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -100,6 +100,7 @@ type OrgTotal struct {
 	RowsRead         uint64 `json:"rows_read,omitempty"`
 	RowsWritten      uint64 `json:"rows_written,omitempty"`
 	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
+	BytesSynced      uint64 `json:"bytes_synced,omitempty"`
 	Databases        uint64 `json:"databases,omitempty"`
 	Locations        uint64 `json:"locations,omitempty"`
 	Groups           uint64 `json:"groups,omitempty"`

--- a/internal/turso/plans.go
+++ b/internal/turso/plans.go
@@ -15,6 +15,7 @@ type Plan struct {
 		RowsRead    uint64 `json:"rowsRead"`
 		RowsWritten uint64 `json:"rowsWritten"`
 		Databases   uint64 `json:"databases"`
+		BytesSynced uint64 `json:"bytesSynced"`
 		Locations   uint64 `json:"locations"`
 		Storage     uint64 `json:"storage"`
 		Groups      uint64 `json:"groups"`


### PR DESCRIPTION
show usage information of bytes synced

<img width="710" alt="Screen Shot 2024-03-14 at 5 23 54 PM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/939c9351-d851-4a7d-b738-4720837341c3">

<img width="598" alt="Screen Shot 2024-03-14 at 5 24 42 PM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/0bac0ce2-8d02-46f3-b5f7-812cc10a20cc">


doesn't show anything bc it is zero
<img width="619" alt="Screen Shot 2024-03-14 at 5 24 57 PM" src="https://github.com/tursodatabase/turso-cli/assets/11340665/5ff3dee5-8d21-46ae-9d7c-bd8529d10528">



