### PR TITLE
Switch to "embedded replica syncs" as metric name

### DIFF
--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -52,7 +52,7 @@ var dbInspectCmd = &cobra.Command{
 		fmt.Printf("Number of rows read: %d\n", dbUsage.Usage.RowsRead)
 		fmt.Printf("Number of rows written: %d\n", dbUsage.Usage.RowsWritten)
 		if dbUsage.Usage.BytesSynced != 0 {
-			fmt.Printf("Number of bytes synced: %s\n", humanize.Bytes(dbUsage.Usage.BytesSynced))
+			fmt.Printf("Embedded syncs: %s\n", humanize.Bytes(dbUsage.Usage.BytesSynced))
 		}
 
 		if len(instances) == 0 {

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -130,10 +130,10 @@ func planUsageTable(orgUsage turso.OrgUsage, current turso.Plan, currentOrg turs
 	addResourceRowBytes(tbl, "storage", orgUsage.Usage.StorageBytesUsed, current.Quotas.Storage, currentOrg.Overages)
 	addResourceRowMillions(tbl, "rows read", orgUsage.Usage.RowsRead, current.Quotas.RowsRead, currentOrg.Overages)
 	addResourceRowMillions(tbl, "rows written", orgUsage.Usage.RowsWritten, current.Quotas.RowsWritten, currentOrg.Overages)
+	addResourceRowBytes(tbl, "embedded syncs", orgUsage.Usage.BytesSynced, current.Quotas.BytesSynced, currentOrg.Overages)
 	addResourceRowCount(tbl, "databases", orgUsage.Usage.Databases, current.Quotas.Databases)
 	addResourceRowCount(tbl, "locations", orgUsage.Usage.Locations, current.Quotas.Locations)
 	addResourceRowCount(tbl, "groups", orgUsage.Usage.Groups, current.Quotas.Groups)
-	addResourceRowBytes(tbl, "bytes synced", orgUsage.Usage.BytesSynced, current.Quotas.BytesSynced, currentOrg.Overages)
 	return tbl
 }
 


### PR DESCRIPTION
The "bytes synced" metric does not necessarily mean anything to users who don't know what it is. Let's add mention of "embedded replica" there for clarity. Mentioning bytes is also redundant because the unit already tells you that.