### PR TITLE
bugfix: avoid using cache in attach commands

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -67,6 +67,18 @@ func getDatabases(client *turso.Client, fresh ...bool) ([]turso.Database, error)
 	return databases, nil
 }
 
+func getDatabasesMap(client *turso.Client, fresh bool) (map[string]turso.Database, error) {
+	databases, err := getDatabases(client, fresh)
+	if err != nil {
+		return nil, err
+	}
+	databasesMap := make(map[string]turso.Database)
+	for _, db := range databases {
+		databasesMap[db.Name] = db
+	}
+	return databasesMap, nil
+}
+
 func getDatabaseNames(client *turso.Client) []string {
 	databases, err := getDatabases(client)
 	if err != nil {

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -46,7 +46,7 @@ var dbGenerateTokenCmd = &cobra.Command{
 
 		var claim *turso.PermissionsClaim
 		if len(flags.AttachClaims()) > 0 {
-			err := validateDBNames(flags.AttachClaims())
+			err := validateDBNames(client, flags.AttachClaims())
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -105,7 +105,7 @@ var shellCmd = &cobra.Command{
 
 			var claim *turso.PermissionsClaim
 			if len(flags.AttachClaims()) > 0 {
-				err := validateDBNames(flags.AttachClaims())
+				err := validateDBNames(client, flags.AttachClaims())
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/group_tokens.go
+++ b/internal/cmd/group_tokens.go
@@ -113,7 +113,7 @@ var groupCreateTokenCmd = &cobra.Command{
 		}
 		var claim *turso.PermissionsClaim
 		if len(flags.AttachClaims()) > 0 {
-			err := validateDBNames(flags.AttachClaims())
+			err := validateDBNames(client, flags.AttachClaims())
 			if err != nil {
 				return err
 			}
@@ -131,10 +131,10 @@ var groupCreateTokenCmd = &cobra.Command{
 	},
 }
 
-func validateDBNames(dbNames []string) error {
-	databases := map[string]string{}
-	for _, db := range getDatabasesCache() {
-		databases[db.Name] = db.ID
+func validateDBNames(client *turso.Client, dbNames []string) error {
+	databases := map[string]struct{}{}
+	for _, dbName := range getDatabaseNames(client) {
+		databases[dbName] = struct{}{}
 	}
 	for _, name := range dbNames {
 		if _, ok := databases[name]; !ok {


### PR DESCRIPTION
If you create a db and then try to attach immediately, it fails since attach cmds look up in the cache and cache might not be populated at that time. This patch changes this behaviour and uses the API call

