### PR TITLE
docs: Add installation instructions for people using Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ brew upgrade turso
 curl -sSfL https://get.tur.so/install.sh | bash
 ```
 
+### Go
+
+```bash
+go install github.com/tursodatabase/turso-cli/cmd/turso@latest
+```
+
 ### Building from source
 
 ```bash


### PR DESCRIPTION
Someone asked about it here: https://github.com/tursodatabase/turso-cli/issues/830