### PR TITLE
Only try to get JWTs for turso.io database URLs

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -158,7 +158,7 @@ var shellCmd = &cobra.Command{
 				authToken = authTokenCamel
 			} else if jwt != "" {
 				authToken = jwt
-			} else {
+			} else if strings.HasSuffix(u.Hostname(), ".turso.io") {
 				client, err := authedTursoClient()
 				if err != nil {
 					return fmt.Errorf("could not create turso client: %w", err)


### PR DESCRIPTION
Fixes shelling into non-platform databases.