### PR TITLE
chore: remove repetition of default value in `--type` & `--csv-separator` flag help text

### DIFF
--- a/internal/cmd/type_flag.go
+++ b/internal/cmd/type_flag.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 var typeFlag string
 
 func addTypeFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&typeFlag, "type", "regular", "Type of the database to create. Possible values: regular, schema. Default: regular.")
+	cmd.Flags().StringVar(&typeFlag, "type", "regular", "Type of the database to create. Possible values: regular, schema.")
 	cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"regular", "schema"}, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/internal/flags/csvseparator.go
+++ b/internal/flags/csvseparator.go
@@ -9,7 +9,7 @@ import (
 var csvSeparatorValue string
 
 func AddCSVSeparator(cmd *cobra.Command) {
-	usage := "CSV separator character. Must be a single character. Defaults to ','"
+	usage := "CSV separator character. Must be a single character."
 	cmd.Flags().StringVar(&csvSeparatorValue, "csv-separator", ",", usage)
 }
 


### PR DESCRIPTION
When running `turso db create -h`, the description for `--type` repeats the default value of "regular".
Removed this from the usage string so it now just uses the default value from `cmd.Flags().StringVar()`

```go
cmd.Flags().StringVar(&typeFlag, "type", "regular", "...")
```

**Before:** 
```bash
Flags:
 --type string Type of the database to create. Possible values: regular, schema. Default: regular. (default "regular")
```

**After:** 
```bash
Flags:
--type string Type of the database to create. Possible values: regular, schema. (default "regular")
```
---

**EDIT**: Noticed this was also the case in `--csv-separator` so changed that too.

**Before:** 
```bash
Flags:
--csv-separator string CSV separator character. Must be a single character. Defaults to ',' (default ",")
```

**After:** 
```bash
Flags:
--csv-separator string CSV separator character. Must be a single character. (default ",")
```
