### PR TITLE
Remove duplicate check that is done on the backend

### DIFF
--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
 	"github.com/tursodatabase/turso-cli/internal/prompt"
-	"github.com/tursodatabase/turso-cli/internal/turso"
 )
 
 func init() {
@@ -30,11 +29,6 @@ var createApiTokensCmd = &cobra.Command{
 		}
 
 		name := strings.TrimSpace(args[0])
-
-		if err := turso.CheckName(name); err != nil {
-			return fmt.Errorf("invalid token name: %w", err)
-		}
-
 		description := fmt.Sprintf("Creating api token %s", internal.Emph(name))
 		bar := prompt.Spinner(description)
 		defer bar.Stop()

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -44,10 +44,6 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		if err := turso.CheckName(name); err != nil {
-			return fmt.Errorf("invalid database name: %w", err)
-		}
-
 		client, err := authedTursoClient()
 		if err != nil {
 			return err

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -86,11 +86,6 @@ var groupsCreateCmd = &cobra.Command{
 			return err
 		}
 
-		name := args[0]
-		if err := turso.CheckName(name); err != nil {
-			return fmt.Errorf("invalid group name: %w", err)
-		}
-
 		location := locationFlag
 		if location == "" {
 			location, _ = closestLocation(client)
@@ -104,6 +99,7 @@ var groupsCreateCmd = &cobra.Command{
 			version = "canary"
 		}
 
+		name := args[0]
 		return createGroup(client, name, location, version)
 	},
 }

--- a/internal/turso/utils.go
+++ b/internal/turso/utils.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
-	"unicode"
 )
 
 func unmarshal[T any](r *http.Response) (T, error) {
@@ -32,21 +30,4 @@ func parseResponseError(res *http.Response) error {
 		return fmt.Errorf("%s", result.Error)
 	}
 	return fmt.Errorf("response failed with status %s", res.Status)
-}
-
-func CheckName(name string) error {
-	if len(name) == 0 || len(name) > 32 {
-		return fmt.Errorf("name must be between 1 and 32 characters long")
-	}
-
-	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") {
-		return fmt.Errorf("name cannot start or end with a hyphen")
-	}
-
-	for _, r := range name {
-		if !(unicode.IsDigit(r) || (unicode.IsLetter(r) && unicode.IsLower(r)) || r == '-') {
-			return fmt.Errorf("name can only contain lowercase letters, numbers, and hyphens")
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Since we've refined our logic there, and the API returns a nice error we should remove the checks done by the client.

Example:
```
➜  turso git:(athos/longer-db-names) turso db create aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
Error: could not create database aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: invalid database name: name must contain between 1 and 52 characters
```