### PR TITLE
Add dependencies to legacy tap

### DIFF
--- a/.goreleaser-legacy-tap.yaml
+++ b/.goreleaser-legacy-tap.yaml
@@ -57,6 +57,8 @@ brews:
     tap:
       owner: chiselstrike
       name: homebrew-tap
+    dependencies:
+      - name: libsql/sqld/sqld
     install: |
       bin.install "turso"
       bash_completion.install "completions/turso.bash" => "turso"


### PR DESCRIPTION
The other goreleaser config has this dependency already.