### PR TITLE
Replace deprecated set-output

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN_TO_SELF }}
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo "{ \"Version\":\"$GITHUB_REF_NAME\"}")
+        run: echo "VERSION=$(echo \"{ \"Version\":\"$GITHUB_REF_NAME\"}\")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Echo
         run: echo ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
For more info see
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/