### PR TITLE
feat: IsSchema and Schema info

### DIFF
--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -94,6 +94,10 @@ var showCmd = &cobra.Command{
 		fmt.Println("Size:          ", humanize.Bytes(dbUsage.Usage.StorageBytesUsed))
 		fmt.Println("Sleeping:      ", formatBool(db.Sleeping))
 		fmt.Println("Bytes Synced:  ", humanize.Bytes(dbUsage.Usage.BytesSynced))
+		fmt.Println("Is Schema:     ", formatBool(db.IsSchema))
+		if db.Schema != "" {
+			fmt.Println("Parent DB ID:  ", db.Schema)
+		}
 
 		fmt.Println()
 

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -96,7 +96,7 @@ var showCmd = &cobra.Command{
 		fmt.Println("Bytes Synced:  ", humanize.Bytes(dbUsage.Usage.BytesSynced))
 		fmt.Println("Is Schema:     ", formatBool(db.IsSchema))
 		if db.Schema != "" {
-			fmt.Println("Parent DB ID:  ", db.Schema)
+			fmt.Println("Schema:        ", db.Schema)
 		}
 
 		fmt.Println()

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -20,6 +20,8 @@ type Database struct {
 	Version       string
 	Group         string
 	Sleeping      bool
+	Schema        string
+	IsSchema      bool `json:"is_schema"`
 }
 
 type DatabasesClient client


### PR DESCRIPTION
Closes #824 

I would prefer to use `Type` to return `Schema`, but our API uses `type` for `logical` so it's a bit confusing to use the same fields for different meanings. We should update the API if we want to make this change here.

We could though do this now if people prefer?

```go
if db.IsSchema {
        fmt.Println("Type: Schema")
    } else {
        fmt.Println("Type: Logical")
    }
```