### PR TITLE
feat(auth): add auth support in turso dev

### DIFF
--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"regexp"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
@@ -18,6 +20,7 @@ func init() {
 	addDevPortFlag(devCmd)
 	addDevFileFlag(devCmd)
 	addDevSqldVersionFlag(devCmd)
+	addAuthJwtFileFlag(devCmd)
 }
 
 var devCmd = &cobra.Command{
@@ -73,19 +76,46 @@ var devCmd = &cobra.Command{
 		addr := fmt.Sprintf("0.0.0.0:%d", devPort)
 		conn := fmt.Sprintf("http://127.0.0.1:%d", devPort)
 
-		sqld := exec.Command("sqld", "--no-welcome", "--http-listen-addr", addr, "-d", tempDir)
+		sqldFlags := []string{
+			"--no-welcome",
+			"--http-listen-addr",
+			addr,
+			"-d",
+			tempDir,
+		}
+
+		if authJwtFile != "" {
+			sqldFlags = append(sqldFlags, "--auth-jwt-key-file", authJwtFile)
+		}
+
+		sqld := exec.Command("sqld", sqldFlags...)
 		sqld.Env = append(os.Environ(), "RUST_LOG=error")
 
 		// Set the appropriate output and error streams for the server process
 		sqld.Stdout = os.Stdout
 		sqld.Stderr = os.Stderr
 
-		// Start the server process
+		// Start the server process.
 		err = sqld.Start()
 		if err != nil {
 			fmt.Fprint(os.Stderr, sqldNotFoundErr)
 			return err
 		}
+
+		// Check if the server is actually running.
+		maxAttempts := 5
+		for i := 0; i < maxAttempts; i++ {
+			_, err := http.Get(conn)
+			if err == nil {
+				break
+			}
+			if i == maxAttempts-1 {
+				fmt.Fprintf(os.Stderr, "sqld not ready after %d health check attempts\n", maxAttempts)
+				return err
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+
 		fmt.Printf("sqld listening on port %s.\n", internal.Emph(devPort))
 
 		fmt.Printf("Use the following URL to configure your libSQL client SDK for local development:\n\n    %s\n\n",
@@ -103,6 +133,12 @@ var devCmd = &cobra.Command{
 
 		// Terminate the server process
 		err = sqld.Process.Kill()
+		if err != nil {
+			return fmt.Errorf("could not kill sqld: %w", err)
+		}
+
+		// Wait for the server process to exit.
+		err = sqld.Wait()
 		if err != nil {
 			return fmt.Errorf("could not kill sqld: %w", err)
 		}

--- a/internal/cmd/dev_auth_jwt_file_flag.go
+++ b/internal/cmd/dev_auth_jwt_file_flag.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var authJwtFile string
+
+func addAuthJwtFileFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&authJwtFile, "auth-jwt-key-file", "a", "", "Path to a file with a JWT decoding key used to authenticate clients in the Hrana and HTTP APIs. The key is either a PKCS#8-encoded Ed25519 public key in PEM, or just plain bytes of the Ed25519 public key in URL-safe base64.")
+}


### PR DESCRIPTION
This PR adds auth support for turso dev command and adds two additional checks when starting and killing the sqld server process. 

## Changes 
The `Start` method launches the `sqld` command without waiting for the process to fully initialize. If `sqld` exits with a non-zero status code due to validation issues or other errors, the error message may be missed by the user since the program prints "sqld is listening" and then blocks the channel.

Calling the `Wait` method immediately after `Start` would cause the program to hang in the happy path. Instead, this PR waits for the server to be ready by pinging the opened connection before printing the success message. It also waits after calling `Kill` to ensure a clean shutdown, as `Kill` does not wait for the process to fully exit.

Lastly, the original purpose of this contribution was to fix https://github.com/tursodatabase/turso-cli/issues/752


## New Experience 

#### With value JWT Key
<img width="789" alt="Screen Shot 2024-06-05 at 11 47 31 AM" src="https://github.com/tursodatabase/turso-cli/assets/65991626/1b38da0d-84a1-44d3-bc83-8436e4a29f48">


#### With invalid JWT key
<img width="788" alt="Screen Shot 2024-06-05 at 11 53 37 AM" src="https://github.com/tursodatabase/turso-cli/assets/65991626/ba83d6e1-3c81-4319-936c-4ead0321b493">



