### PR TITLE
Update word `sleeping` to display `archived`

### DIFF
--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -45,7 +45,7 @@ func printDBListTable(databases []turso.Database) {
 	}
 
 	if !shouldPrintSleeping(databases) {
-		headers, data = removeColumn(headers, data, "Sleeping")
+		headers, data = removeColumn(headers, data, "Archived")
 	}
 
 	printTable(headers, data)
@@ -87,7 +87,7 @@ func dbListTable(databases []turso.Database) (headers []string, data [][]string)
 		return data[i][0] < data[j][0]
 	})
 
-	return []string{"Name", "Locations", "Group", "URL", "Sleeping"}, data
+	return []string{"Name", "Locations", "Group", "URL", "Archived"}, data
 }
 
 func removeColumn(headers []string, data [][]string, column string) ([]string, [][]string) {

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -92,7 +92,7 @@ var showCmd = &cobra.Command{
 		}
 		fmt.Println("Locations:     ", strings.Join(regions, ", "))
 		fmt.Println("Size:          ", humanize.Bytes(dbUsage.Usage.StorageBytesUsed))
-		fmt.Println("Sleeping:      ", formatBool(db.Sleeping))
+		fmt.Println("Archived:      ", formatBool(db.Sleeping))
 		fmt.Println("Bytes Synced:  ", humanize.Bytes(dbUsage.Usage.BytesSynced))
 		fmt.Println("Is Schema:     ", formatBool(db.IsSchema))
 		if db.Schema != "" {

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -226,7 +226,7 @@ func groupsTable(groups []turso.Group) [][]string {
 func aggregateGroupStatus(group turso.Group) string {
 	status := "Healthy"
 	if group.Archived {
-		return "Sleeping 💤"
+		return "Archived 💤"
 	}
 	allIdle := true
 	for _, locationStatus := range group.Status.Locations {


### PR DESCRIPTION
The CLI displays `sleeping` for archived databases and groups. It is incorrect and confusing as we also have cold starts. To distinguish properly, this patch fixes the wording and uses `archived`