### PR TITLE
feat: db list group and schema filters

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -272,7 +272,7 @@ func signupHint(config *settings.Settings) {
 		return
 	}
 
-	dbs, err := client.Databases.List()
+	dbs, err := client.Databases.List(nil)
 	if err != nil || len(dbs) != 0 {
 		return
 	}

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -59,7 +59,7 @@ func getDatabases(client *turso.Client, fresh ...bool) ([]turso.Database, error)
 	if cachedNames := getDatabasesCache(); !skipCache && cachedNames != nil {
 		return cachedNames, nil
 	}
-	databases, err := client.Databases.List()
+	databases, err := client.Databases.List(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -8,8 +8,13 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+var groupFilter string
+var schemaFilter string
+
 func init() {
 	dbCmd.AddCommand(listCmd)
+	listCmd.Flags().StringVarP(&groupFilter, "group", "g", "", "Filter databases by group")
+	listCmd.Flags().StringVarP(&schemaFilter, "schema", "s", "", "Filter databases by schema")
 }
 
 var listCmd = &cobra.Command{
@@ -24,7 +29,15 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		databases, err := client.Databases.List()
+		options := make(map[string]string)
+		if groupFilter != "" {
+			options["group"] = groupFilter
+		}
+		if schemaFilter != "" {
+			options["schema"] = schemaFilter
+		}
+
+		databases, err := client.Databases.List(options)
 		if err != nil {
 			return err
 		}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -27,19 +27,18 @@ type Database struct {
 
 type DatabasesClient client
 
-func (d *DatabasesClient) List(options ...map[string]string) ([]Database, error) {
+func (d *DatabasesClient) List(options map[string]string) ([]Database, error) {
 	path := d.URL("")
 
-	if len(options) > 0 && options[0] != nil {
-		query := url.Values{}
-		for key, value := range options[0] {
-			if value != "" {
-				query.Add(key, value)
-			}
+	query := url.Values{}
+	for key, value := range options {
+		if value != "" {
+			query.Add(key, value)
 		}
-		if len(query) > 0 {
-			path += "?" + query.Encode()
-		}
+	}
+
+	if len(query) > 0 {
+		path += "?" + query.Encode()
 	}
 
 	r, err := d.client.Get(path, nil)

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -26,8 +27,22 @@ type Database struct {
 
 type DatabasesClient client
 
-func (d *DatabasesClient) List() ([]Database, error) {
-	r, err := d.client.Get(d.URL(""), nil)
+func (d *DatabasesClient) List(options ...map[string]string) ([]Database, error) {
+	path := d.URL("")
+
+	if len(options) > 0 && options[0] != nil {
+		query := url.Values{}
+		for key, value := range options[0] {
+			if value != "" {
+				query.Add(key, value)
+			}
+		}
+		if len(query) > 0 {
+			path += "?" + query.Encode()
+		}
+	}
+
+	r, err := d.client.Get(path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database listing: %s", err)
 	}


### PR DESCRIPTION
This adds the following flags for `db list`:

* `--group <group-name>`
```bash
go run cmd/turso/main.go db list --group vectors
NAME                 URL
mydb                 libsql://mydb-notrab.turso.io
super-fantomette     libsql://super-fantomette-notrab.turso.io
tutorial             libsql://tutorial-notrab.turso.io

```

* `--schema <schema-database-name>`
```bash
go run cmd/turso/main.go db list --schema parent-db
NAME             URL
child-db         libsql://child-db-notrab.turso.io
child-db-2       libsql://child-db-2-notrab.turso.io
new-child-db     libsql://new-child-db-notrab.turso.io
```