### PR TITLE
feat(db/create): allow size-limit flag

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -30,6 +30,7 @@ func init() {
 	addEnableExtensionsFlag(createCmd)
 	addSchemaFlag(createCmd)
 	addTypeFlag(createCmd)
+	addSizeLimitFlag(createCmd)
 }
 
 var createCmd = &cobra.Command{
@@ -77,7 +78,7 @@ var createCmd = &cobra.Command{
 		spinner := prompt.Spinner(fmt.Sprintf("Creating database %s in group %s...", internal.Emph(name), internal.Emph(group)))
 		defer spinner.Stop()
 
-		if _, err = client.Databases.Create(name, location, "", "", group, schemaFlag, typeFlag == "schema", seed); err != nil {
+		if _, err = client.Databases.Create(name, location, "", "", group, schemaFlag, typeFlag == "schema", seed, sizeLimitFlag); err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)
 		}
 

--- a/internal/cmd/db_size_limit_flag.go
+++ b/internal/cmd/db_size_limit_flag.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var sizeLimitFlag string
+
+func addSizeLimitFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&sizeLimitFlag, "size-limit", "", "The maximum size of the database in bytes. Values with units are accepted, e.g. 1mb, 256mb, 1gb")
+}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -108,10 +108,11 @@ type CreateDatabaseBody struct {
 	Seed       *DBSeed `json:"seed,omitempty"`
 	Schema     string  `json:"schema,omitempty"`
 	IsSchema   bool    `json:"is_schema,omitempty"`
+	SizeLimit  string  `json:"size_limit,omitempty"`
 }
 
-func (d *DatabasesClient) Create(name, location, image, extensions, group string, schema string, isSchema bool, seed *DBSeed) (*CreateDatabaseResponse, error) {
-	params := CreateDatabaseBody{name, location, image, extensions, group, seed, schema, isSchema}
+func (d *DatabasesClient) Create(name, location, image, extensions, group string, schema string, isSchema bool, seed *DBSeed, sizeLimit string) (*CreateDatabaseResponse, error) {
+	params := CreateDatabaseBody{name, location, image, extensions, group, seed, schema, isSchema, sizeLimit}
 
 	body, err := marshal(params)
 	if err != nil {


### PR DESCRIPTION
Fixes #258

```bash
go run ./cmd/turso/main.go db create --size-limit 50mb
```

I created a new file for the `flag` because that seems to be a newer convention than I did previously. We should probably cleanup the old (if it is old) way.