### PR TITLE
feat(db/create): ask to wake sleeping groups before create

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -55,6 +55,27 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
+		groupInfo, err := getGroup(client, group)
+		if err != nil {
+			return fmt.Errorf("failed to get group info: %w", err)
+		}
+
+		groupStatus := aggregateGroupStatus(groupInfo)
+		if groupStatus == "Archived 💤" {
+			fmt.Printf("The group %s is currently archived. Do you want to wake it up? [Y/n]: ", internal.Emph(group))
+			var response string
+			fmt.Scanln(&response)
+			if response == "" || response == "y" || response == "yes" {
+				err = unarchiveGroup(client, group)
+				if err != nil {
+					return fmt.Errorf("failed to wake up group: %w", err)
+				}
+				fmt.Printf("Group %s has been woken up.\n", internal.Emph(group))
+			} else {
+				return fmt.Errorf("cannot create a database in an archived group. Please wake up the group first")
+			}
+		}
+
 		location, err := locationFromFlag(client)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #894

This does however use a mix of the `sleeping` and `archived` terminology. We should clean that up when we know which word we want to go with.