### PR TITLE
Replace `Sleeping` with `Archived`

### DIFF
--- a/internal/cmd/db_wakeup.go
+++ b/internal/cmd/db_wakeup.go
@@ -15,8 +15,8 @@ func init() {
 }
 
 var wakeUpDbCmd = &cobra.Command{
-	Use:               "wakeup <db-name>",
-	Short:             "Wake up a database",
+	Use:               "unarchive <db-name>",
+	Short:             "Unarchive a database",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -33,7 +33,7 @@ var wakeUpDbCmd = &cobra.Command{
 
 func wakeupDatabase(client *turso.Client, name string) error {
 	start := time.Now()
-	s := prompt.Spinner(fmt.Sprintf("Waking up database %s... ", internal.Emph(name)))
+	s := prompt.Spinner(fmt.Sprintf("Unarchiving database %s... ", internal.Emph(name)))
 	defer s.Stop()
 
 	if err := client.Databases.Wakeup(name); err != nil {
@@ -42,6 +42,6 @@ func wakeupDatabase(client *turso.Client, name string) error {
 	s.Stop()
 	elapsed := time.Since(start)
 	invalidateDatabasesCache()
-	fmt.Printf("Waked up database %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
+	fmt.Printf("Unarchived database %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
 	return nil
 }

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -112,8 +112,8 @@ var groupsCreateCmd = &cobra.Command{
 }
 
 var unarchiveGroupCmd = &cobra.Command{
-	Use:               "wakeup <group-name>",
-	Short:             "Wake up a database group",
+	Use:               "unarchive <group-name>",
+	Short:             "Unarchive a database group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: groupArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -185,7 +185,7 @@ func createGroup(client *turso.Client, name, location, version string) error {
 
 func unarchiveGroup(client *turso.Client, name string) error {
 	start := time.Now()
-	s := prompt.Spinner(fmt.Sprintf("Waking up group %s... ", internal.Emph(name)))
+	s := prompt.Spinner(fmt.Sprintf("Unarchiving group %s... ", internal.Emph(name)))
 	defer s.Stop()
 
 	if err := client.Groups.Unarchive(name); err != nil {
@@ -194,7 +194,7 @@ func unarchiveGroup(client *turso.Client, name string) error {
 	s.Stop()
 	elapsed := time.Since(start)
 	invalidateGroupsCache(client.Org)
-	fmt.Printf("Woke up group %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
+	fmt.Printf("Unarchived group %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
 	return nil
 }
 

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -342,7 +342,7 @@ func (d *DatabasesClient) Wakeup(database string) error {
 	url := d.URL(fmt.Sprintf("/%s/wakeup", database))
 	r, err := d.client.Post(url, nil)
 	if err != nil {
-		return fmt.Errorf("failed to wakeup database: %w", err)
+		return fmt.Errorf("failed to unarchive database: %w", err)
 	}
 	defer r.Body.Close()
 
@@ -352,7 +352,7 @@ func (d *DatabasesClient) Wakeup(database string) error {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to wakeup database: %w", parseResponseError(r))
+		return fmt.Errorf("failed to unarchive database: %w", parseResponseError(r))
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Some users are getting confused with the terminology `Sleeping` as we also have cold starts. This patch changes the word to `Archived`. This also changes the word `Wake up` to `Unarchive`.

Previously, we had a command `turso group wakeup <group name>` which is now replaced with `turso group unarchive <group name>`

Internal slack discussion: [1](https://turso.slack.com/archives/C02J5GYN8NB/p1721980720846099), [2](https://turso.slack.com/archives/C02J5GYN8NB/p1722867218607089)
