### PR TITLE
wait for sqld process in the dev mode in order to capture unexpected exists (crashes, etc)

### DIFF
--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -149,7 +149,7 @@ var devCmd = &cobra.Command{
 		}
 
 		// Wait for the server process to exit.
-		err = sqld.Wait()
+		err = <-waitCh
 		if err != nil {
 			return fmt.Errorf("could not kill sqld: %w", err)
 		}


### PR DESCRIPTION
## Context

`turso dev` doesn't wait for `sqld` process and if it crashes (which is rare situation but still) - dev mode will continue to work and will return an error only when user will try to interrupt it:
```
could not kill sqld: signal: segmentation fault (core dumped)
```

This PR concurrently waits for process to finish and for interruption signal in order to make crashes more obvious:
```
Error: sqld exited unexpectedly: signal: segmentation fault (core dumped)
```