### PR TITLE
Remove vector version

### DIFF
--- a/internal/flags/version.go
+++ b/internal/flags/version.go
@@ -9,7 +9,7 @@ var versionFlag string
 func AddVersion(cmd *cobra.Command, desc string) {
 	cmd.Flags().StringVar(&versionFlag, "version", "", desc)
 	_ = cmd.RegisterFlagCompletionFunc("version", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"latest", "canary", "vector"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"latest", "canary"}, cobra.ShellCompDirectiveNoFileComp
 	})
 }
 


### PR DESCRIPTION
It is already integrated into latest, no need to keep it as a separate version.