### PR TITLE
feat(db/destroy): allow autocomplete for multi database-name

### DIFF
--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -22,7 +22,7 @@ var destroyCmd = &cobra.Command{
 	Use:               "destroy <database-name>",
 	Short:             "Destroy a database.",
 	Args:              cobra.MinimumNArgs(1),
-	ValidArgsFunction: dbNameArg,
+	ValidArgsFunction: dbNameListArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -296,6 +297,20 @@ func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 		return getDatabaseNames(client), cobra.ShellCompDirectiveNoFileComp
 	}
 	return []string{}, cobra.ShellCompDirectiveNoFileComp
+}
+
+func dbNameListArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := authedTursoClient()
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	var dbNameList = make([]string, 0)
+	for _, dbName := range getDatabaseNames(client) {
+		if !slices.Contains(args, dbName) {
+			dbNameList = append(dbNameList, dbName)
+		}
+	}
+	return dbNameList, cobra.ShellCompDirectiveNoFileComp
 }
 
 func dbNameAndOrgArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Hi!  My name is Rafael and I am at the beginning of my journey with the Go language. I saw this "good first issue" as an ideal opportunity to learn and engage actively within the open-source community. I greatly appreciate any feedback from more experienced Go developers.

This contribution aims to address the issue outlined in #702, highlighting that the autocomplete feature is not functioning correctly when handling multiple databases.

The root of this issue lies in the `dbNameArg` function, which only returns the list of databases if the number of arguments is zero. However, in order to enhance the autocomplete functionality for multiple databases, I am proposing the addition of the `dbNameListArg` function. 

This new function will return a list of all databases even when multiple arguments are provided to the call. Moreover, I have ensured that the autocomplete feature only includes databases in its completion suggestions that have not already been typed into the command. I achieved this by using the `slices.Contains` tool, which has been part of the standard Go library since version 1.21.

I decided to introduce this enhancement as a new function rather than modify the existing dbNameArg function. This is because modifications to dbNameArg could potentially have negative implications for commands like `ispect` and `show`, which expect a unique database name occurrence.

This new approach would permit us to improve the autocomplete functionality without causing undesired impacts on other functionalities of the system.

I would like to request a review of this proposed solution to address the issue at hand and am open to discussing any potential enhancements or concerns that may arise.