### PR TITLE
Issue#917: Add a check to know if database is archived

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -185,6 +185,9 @@ var shellCmd = &cobra.Command{
 			dbUrl = u.String()
 		}
 
+		if db != nil && db.Sleeping {
+			return fmt.Errorf("Your DB might be archived. Please run `turso group unarchive " + db.Group + "` to unarchive it")
+		}
 		connectionInfo := getConnectionInfo(urlString, db)
 		schemaDb := false
 		if db != nil {


### PR DESCRIPTION
#917 
Add a check to see if the database is archived. If yes, a warning message prompting the user to unarchive the group this database belongs to will appear.