### PR TITLE
chore: update docs link to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is [reference documentation](https://docs.turso.tech/reference/turso-cli)
 available.
 
 For a guided walkthrough, follow the
-[Turso CLI tutorial](https://docs.turso.tech/tutorials/get-started-turso-cli).
+[Turso Quickstart docs](https://docs.turso.tech/quickstart).
 
 ## Installation
 

--- a/internal/cmd/login.html
+++ b/internal/cmd/login.html
@@ -56,7 +56,7 @@
           <a
             class="login-section__disclaimer-link"
             target="_blank"
-            href="https://docs.turso.tech/tutorials/get-started-turso-cli/step-01-installation"
+            href="https://docs.turso.tech/quickstart"
           >
             read our Docs↗</a
           >


### PR DESCRIPTION
While checking how the login was working, I stumbled upon the `index.html` file.

The current link to the CLI seems to be an old one that returns a redirect. Just saving a few request by changing it to `/quickstart` instead.

```sh
$ curl -I https://docs.turso.tech/tutorials/get-started-turso-cli
HTTP/2 308
age: 65020
cache-control: public, max-age=0, must-revalidate
date: Sat, 26 Oct 2024 03:52:30 GMT
location: /quickstart
```