### PR TITLE
refactor: use http instead of websocket in shell by default

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -34,9 +34,9 @@ func init() {
 }
 
 func getURL(db *turso.Database, client *turso.Client, http bool) (string, error) {
-	scheme := "wss"
-	if http {
-		scheme = "https"
+	scheme := "https"
+	if !http {
+		scheme = "wss"
 	}
 
 	if instanceFlag == "" && locationFlag == "" {


### PR DESCRIPTION
- use http instead of websocket in shell by default