### PR TITLE
Glauber/aws improvements

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"math"
 	"os"
-	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
@@ -130,50 +128,9 @@ func envAccessToken() (string, error) {
 	return token, nil
 }
 
-type latMap struct {
-	id  string
-	lat int
-}
-
 func locations(client *turso.Client) (map[string]string, error) {
 	settings, _ := settings.ReadSettings()
 	return readLocations(settings, client)
-}
-
-func latencies(client *turso.Client) (map[string]int, error) {
-	settings, _ := settings.ReadSettings()
-	locations, err := readLocations(settings, client)
-	if err != nil {
-		return nil, err
-	}
-
-	var wg sync.WaitGroup
-	latencies := make(map[string]int)
-	c := make(chan latMap, len(locations))
-	for id := range locations {
-		wg.Add(1)
-		go func(id string) {
-			defer wg.Done()
-			measure := math.MaxInt
-			// XXX: Running this in different goroutines makes all latencies dogslow.
-			// Not sure if this is contention at the client or API level
-			for i := 0; i < 3; i++ {
-				d := turso.ProbeLocation(id)
-				if d != nil {
-					measure = int(math.Min(float64(d.Milliseconds()), float64(measure)))
-				}
-			}
-			c <- latMap{id: id, lat: measure}
-		}(id)
-	}
-
-	wg.Wait()
-	close(c)
-
-	for kvp := range c {
-		latencies[kvp.id] = kvp.lat
-	}
-	return latencies, nil
 }
 
 func readLocations(settings *settings.Settings, client *turso.Client) (map[string]string, error) {

--- a/internal/cmd/latencies.go
+++ b/internal/cmd/latencies.go
@@ -1,9 +1,0 @@
-package cmd
-
-import "github.com/spf13/cobra"
-
-var latencyFlag bool
-
-func addLatencyFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&latencyFlag, "show-latencies", "l", false, "Display latencies from your current location to each of Turso's locations")
-}


### PR DESCRIPTION
Improve AWS / Fly communication

* do not use the -l flag anymore, as it is meaningless on AWS.
* Clearly separate AWS regions from Fly regions, so the fact that both exist is not lost by accident.