### PR TITLE
Require users to add a --beta flag for AWS

### DIFF
--- a/internal/cmd/beta.go
+++ b/internal/cmd/beta.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var betaFlag bool
+
+func addBetaFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&betaFlag, "beta", false, "enable beta features")
+}

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -31,6 +31,7 @@ func init() {
 	addSchemaFlag(createCmd)
 	addTypeFlag(createCmd)
 	addSizeLimitFlag(createCmd)
+	addBetaFlag(createCmd)
 }
 
 var createCmd = &cobra.Command{

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -24,6 +25,7 @@ func init() {
 	addLocationFlag(groupsCreateCmd, "Create the group primary in the specified location")
 	addWaitFlag(groupsCreateCmd, "Wait for group to be ready")
 	addCanaryFlag(groupsCreateCmd)
+	addBetaFlag(groupsCreateCmd)
 	flags.AddVersion(groupsCreateCmd, "Version of the group. Valid values: 'latest', 'canary' or 'vector'")
 	groupCmd.AddCommand(groupsDestroyCmd)
 	addYesFlag(groupsDestroyCmd, "Confirms the destruction of the group, with all its locations and databases.")
@@ -163,6 +165,14 @@ var groupsDestroyCmd = &cobra.Command{
 }
 
 func createGroup(client *turso.Client, name, location, version string) error {
+	if strings.HasPrefix(location, "aws-") && !betaFlag {
+		fmt.Printf("AWS regions are currently in %s. Not all features are available in all plans.\nFor a complete list, check %s.\n",
+			internal.Emph("beta"), internal.Emph("https://docs.turso.tech/cloud-providers"))
+
+		fmt.Printf("To create a database on AWS, add the %s flag.\n", internal.Emph("--beta"))
+		return fmt.Errorf("--beta flag not passed")
+	}
+
 	start := time.Now()
 	description := fmt.Sprintf("Creating group %s at %s...", internal.Emph(name), internal.Emph(location))
 	spinner := prompt.Spinner(description)


### PR DESCRIPTION
This matches the UI experience of communicating the restrictions clearly.