### PR TITLE
Use the /usage/queries endpoint instead of obsolete /stats endpoint :confetti_ball: 

### DIFF
--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -98,7 +98,7 @@ func handleInspectQueries(client *turso.Client, database string) error {
 		return err
 	}
 	tbl := table.New("QUERY", "ROWS WRITTEN", "ROWS READ")
-	for _, query := range stats.TopQueries {
+	for _, query := range stats {
 		tbl.AddRow(query.Query, query.RowsWritten, query.RowsRead)
 	}
 	tbl.Print()


### PR DESCRIPTION
Let's use modern `/usage/queries` endpoint for query stats instead of obsolete `/stats` endpoint (which do not work for DBs in the AWS).

We will change logic here and now show statistics about queries executed in the DB during **last 1 day**

```
$> turso db inspect just-little --queries
QUERY                                  ROWS WRITTEN  ROWS READ  
SELECT * FROM test                     0             87         
INSERT INTO test VALUES (1), (2), (3)  3             0          
SELECT * FROM sqlite_master            0             16         
SELECT 1                               0             0          
```