### PR TITLE
also mark the default region on AWS

### DIFF
--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -78,7 +78,12 @@ var regionsCmd = &cobra.Command{
 		fmt.Println(internal.Emph("AWS (beta) Regions:"))
 		for _, location := range awsIds {
 			description := locations[location]
-			awsTbl.AddRow(location, description)
+			if location == closest {
+				description = fmt.Sprintf("%s  [default]", description)
+				awsTbl.AddRow(internal.Emph(location), internal.Emph(description))
+			} else {
+				awsTbl.AddRow(location, description)
+			}
 		}
 		awsTbl.Print()
 		return nil


### PR DESCRIPTION
With the new region service for AWS (not published yet), the default location could be on AWS. If it is, mark it as the default.