### PR TITLE
Add `turso db import` command for importing SQLite files

### DIFF
--- a/internal/cmd/db_import.go
+++ b/internal/cmd/db_import.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	dbCmd.AddCommand(importCmd)
+}
+
+var importCmd = &cobra.Command{
+	Use:               "import [filename]",
+	Short:             "Import a SQLite database file to Turso.",
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: noFilesArg,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		filename := args[0]
+		fromFileFlag = filename
+		name := sanitizeDatabaseName(filename)
+		return CreateDatabase(name)
+	},
+}
+
+// Sanitize a SQLite database filename to be used as a cloud database name.
+func sanitizeDatabaseName(filename string) string {
+	base := filepath.Base(filename)
+	return strings.TrimSuffix(base, ".db")
+}


### PR DESCRIPTION
The functionality is the same as with `turso db create --from-file` but the command is more discoverable.

With this command, you can do:

```
$ sqlite3 hello.db
SQLite version 3.49.1 2025-02-18 13:38:58
Enter ".help" for usage hints.
sqlite> PRAGMA journal_mode = WAL;
wal
sqlite> CREATE TABLE t(x);
sqlite> INSERT INTO t(x);
sqlite> INSERT INTO t VALUEs ('Hello, world!');
sqlite>
$ turso db import hello.db
Created database hello at group aws in 1.953s.

Start an interactive SQL shell with:

   turso db shell hello

To see information about the database, including a connection URL, run:

   turso db show hello

To get an authentication token for the database, run:

   turso db tokens create hello
```
