### PR TITLE
Fix bug 'not being able to create db in existing fly group' and improve errors

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -200,6 +200,8 @@ func locationFromFlag(client *turso.Client, group turso.Group, groups []turso.Gr
 		if !groupContainsLocation {
 			return "", fmt.Errorf("location '%s' is not valid for group '%s'. The group has the following locations: %v. You can use 'turso group locations add' to add a new location to the group", loc, group.Name, strings.Join(group.Locations, ", "))
 		}
+
+		return loc, nil
 	}
 	if !isValidLocation(client, loc) {
 		return "", fmt.Errorf("location '%s' is not valid", loc)

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -146,18 +146,14 @@ func groupFromFlag(groups []turso.Group) (turso.Group, error) {
 
 	if groupFlag != "" {
 		if !groupExists(groups, groupFlag) {
-			groupNames := make([]string, len(groups))
-			for i, g := range groups {
-				groupNames[i] = g.Name
-			}
-			return turso.Group{}, fmt.Errorf("group %s does not exist. You have the following groups: %v. You can use 'turso group create' to create a new group", groupFlag, strings.Join(groupNames, ", "))
+			return turso.Group{}, fmt.Errorf("group %s does not exist. Please double-check the name. You can run 'turso group list' to get a list of your groups, or 'turso group create' to make a new one", groupFlag)
 		}
 		for _, group := range groups {
 			if group.Name == groupFlag {
 				return group, nil
 			}
 		}
-		return turso.Group{}, fmt.Errorf("group %s does not exist", groupFlag)
+		return turso.Group{}, fmt.Errorf("group %s does not exist. Please double-check the name. You can run 'turso group list' to get a list of your groups, or 'turso group create' to make a new one", groupFlag)
 	}
 
 	switch {


### PR DESCRIPTION
Free tier user was not able to create a DB in an existing fly group after AWS rollout. Logic after this PR:

- If location flag is NOT provided, and user has no groups, defaults to `closestLocation`. `isValidLocation` check is made.

- If location flag is NOT provided, and user has groups, defaults to `group.Primary`. `isValidLocation` check is NOT made.

- If location flag IS provided, and user has no groups, uses that location. `isValidLocation` check is made.

- If location flag IS provided, and user HAS groups, uses that location, but the group must also have that location. `isValidLocation` check is NOT made.

Also improve the error messages a bit