### PR TITLE
add the organization header to HTTP requests

### DIFF
--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -87,6 +87,7 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader, contentType 
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("turso-cli/%s (%s/%s)", parsedCliVersion, runtime.GOOS, runtime.GOARCH))
 	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("x-turso-organization", t.Org)
 	return req, nil
 }
 


### PR DESCRIPTION
Our API requires that we pass the organization header to get the organization context.

One example where this matters is when getting the list of locations. Some organizations are allowed to see the Fly locations, while other organizations from the same user may not.