### PR TITLE
Fix broken orgs

### DIFF
--- a/internal/turso/locations.go
+++ b/internal/turso/locations.go
@@ -28,7 +28,8 @@ type LocationResponse struct {
 }
 
 func (c *LocationsClient) List() (map[string]string, error) {
-	r, err := c.client.Get("/v1/locations", nil)
+	// locations endpoint will return different value per org (for example, only some orgs can use Fly locations)
+	r, err := c.client.GetWithHeaders("/v1/locations", nil, Header("x-turso-organization", c.client.Org))
 	if err != nil {
 		return nil, fmt.Errorf("failed to request locations: %s", err)
 	}

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -87,7 +87,6 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader, contentType 
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("turso-cli/%s (%s/%s)", parsedCliVersion, runtime.GOOS, runtime.GOARCH))
 	req.Header.Add("Content-Type", contentType)
-	req.Header.Add("x-turso-organization", t.Org)
 	return req, nil
 }
 

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -61,8 +61,8 @@ func New(base *url.URL, token string, cliVersion string, org string) *Client {
 	return c
 }
 
-func (t *Client) newRequest(method, urlPath string, body io.Reader, contentType string) (*http.Request, error) {
-	if contentType == "" {
+func (t *Client) newRequest(method, urlPath string, body io.Reader, extraHeaders map[string]string) (*http.Request, error) {
+	if _, exists := extraHeaders["Content-Type"]; !exists {
 		return nil, fmt.Errorf("content type is required")
 	}
 	url, err := url.Parse(t.baseUrl.String())
@@ -86,12 +86,14 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader, contentType 
 		parsedCliVersion = t.cliVersion[1:]
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("turso-cli/%s (%s/%s)", parsedCliVersion, runtime.GOOS, runtime.GOARCH))
-	req.Header.Add("Content-Type", contentType)
+	for header, value := range extraHeaders {
+		req.Header.Add(header, value)
+	}
 	return req, nil
 }
 
-func (t *Client) do(method, path string, body io.Reader, contentType string) (*http.Response, error) {
-	req, err := t.newRequest(method, path, body, contentType)
+func (t *Client) do(method, path string, body io.Reader, extraHeaders map[string]string) (*http.Response, error) {
+	req, err := t.newRequest(method, path, body, extraHeaders)
 	var reqDump string
 	if flags.Debug() {
 		reqDump = dumpRequest(req)
@@ -134,24 +136,35 @@ func dumpResponse(req *http.Response) string {
 	return string(dump)
 }
 
+func Header(key, value string) map[string]string {
+	return map[string]string{
+		key: value,
+	}
+}
+
 func (t *Client) Get(path string, body io.Reader) (*http.Response, error) {
-	return t.do("GET", path, body, "application/json")
+	return t.do("GET", path, body, Header("Content-Type", "application/json"))
+}
+
+func (t *Client) GetWithHeaders(path string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	headers["Content-Type"] = "application/json"
+	return t.do("GET", path, body, headers)
 }
 
 func (t *Client) Post(path string, body io.Reader) (*http.Response, error) {
-	return t.do("POST", path, body, "application/json")
+	return t.do("POST", path, body, Header("Content-Type", "application/json"))
 }
 
 func (t *Client) PostBinary(path string, body io.Reader) (*http.Response, error) {
-	return t.do("POST", path, body, "application/octet-stream")
+	return t.do("POST", path, body, Header("Content-Type", "application/octet-stream"))
 }
 
 func (t *Client) Patch(path string, body io.Reader) (*http.Response, error) {
-	return t.do("PATCH", path, body, "application/json")
+	return t.do("PATCH", path, body, Header("Content-Type", "application/json"))
 }
 
 func (t *Client) Put(path string, body io.Reader) (*http.Response, error) {
-	return t.do("PUT", path, body, "application/json")
+	return t.do("PUT", path, body, Header("Content-Type", "application/json"))
 }
 
 func (t *Client) Upload(path string, fileData *os.File) (*http.Response, error) {
@@ -169,7 +182,7 @@ func (t *Client) Upload(path string, fileData *os.File) (*http.Response, error) 
 		}
 		bodyWriter.CloseWithError(writer.Close())
 	}()
-	req, err := t.newRequest("POST", path, body, writer.FormDataContentType())
+	req, err := t.newRequest("POST", path, body, Header("Content-Type", writer.FormDataContentType()))
 	if err != nil {
 		return nil, err
 	}
@@ -181,5 +194,5 @@ func (t *Client) Upload(path string, fileData *os.File) (*http.Response, error) 
 }
 
 func (t *Client) Delete(path string, body io.Reader) (*http.Response, error) {
-	return t.do("DELETE", path, body, "application/json")
+	return t.do("DELETE", path, body, Header("Content-Type", "application/json"))
 }


### PR DESCRIPTION
A user reported on discord that after deleting the organization, he could no longer log in.
All of that happens if the deletion is on the web. If the deletion itself is on the CLI, the delete command will take care of everything. But if you delete your organization on the web, then the local cache file still has the name of the old organization and will try to use it.

That led to two issues:

* the patch to fix locations actually broke logging in once you delete an organization. That is because we now pass the organization on the headers, as some commands are organization aware. So in this patch we'll do the opposite, and only use the location header where we are sure we need it, instead of everywhere.
* Even when that is taken care of, trying to list locations get us to a limbo, so we can be nice, and auto-fix that.
* Other issues will have to be fixed by clearing the cache, but the user is at least already logged in at this point
* 