### PR TITLE
use new v2 locations endpoints

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -152,12 +152,27 @@ func readLocations(settings *settings.Settings, client *turso.Client) (map[strin
 		return locations, nil
 	}
 
-	locations, err := client.Locations.List()
+	locationsMap, err := mapLocations(client)
 	if err != nil {
 		return nil, err
 	}
 
+	locations := make(map[string]string, 32)
+	for _, platformLocations := range locationsMap {
+		for loc, desc := range platformLocations {
+			locations[loc] = desc
+		}
+	}
+
 	setLocationsCache(locations)
+	return locations, nil
+}
+
+func mapLocations(client *turso.Client) (map[string]map[string]string, error) {
+	locations, err := client.Organizations.Locations()
+	if err != nil {
+		return nil, err
+	}
 	return locations, nil
 }
 

--- a/internal/turso/locations.go
+++ b/internal/turso/locations.go
@@ -27,27 +27,6 @@ type LocationResponse struct {
 	Closest     []Location
 }
 
-func (c *LocationsClient) List() (map[string]string, error) {
-	// locations endpoint will return different value per org (for example, only some orgs can use Fly locations)
-	r, err := c.client.GetWithHeaders("/v1/locations", nil, Header("x-turso-organization", c.client.Org))
-	if err != nil {
-		return nil, fmt.Errorf("failed to request locations: %s", err)
-	}
-	defer r.Body.Close()
-
-	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get locations: %w", parseResponseError(r))
-
-	}
-
-	data, err := unmarshal[LocationsResponse](r)
-	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize locations response: %w", err)
-	}
-
-	return data.Locations, nil
-}
-
 func (c *LocationsClient) Get(location string) (LocationResponse, error) {
 	r, err := c.client.Get("/v1/locations/"+location, nil)
 	if err != nil {

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -140,6 +140,36 @@ func (c *OrganizationsClient) Usage() (OrgUsage, error) {
 	return body.OrgUsage, nil
 }
 
+type OrgLocations map[string]map[string]string
+
+type OrgLocationsResponse struct {
+	Locations OrgLocations
+}
+
+func (c *OrganizationsClient) Locations() (OrgLocations, error) {
+	prefix := "/v2"
+	if c.client.Org != "" {
+		prefix = "/v2/organizations/" + c.client.Org
+	}
+
+	r, err := c.client.Get(prefix+"/locations", nil)
+	if err != nil {
+		return OrgLocations{}, fmt.Errorf("failed to get org locations: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		err, _ := unmarshal[string](r)
+		return OrgLocations{}, fmt.Errorf("failed to get locations: %d %s", r.StatusCode, err)
+	}
+
+	body, err := unmarshal[OrgLocationsResponse](r)
+	if err != nil {
+		return OrgLocations{}, err
+	}
+	return body.Locations, nil
+}
+
 func (c *OrganizationsClient) SetOverages(slug string, toggle bool) error {
 	path := "/v1/organizations/" + slug
 	body, err := marshal(map[string]bool{"overages": toggle})


### PR DESCRIPTION
That new endpoint clearly distinguishes between different platforms, and is safer to use across organizations - we don't need to pass a header anymore.