### PR TITLE
feat: list and paginate databases/branches

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -15,6 +15,7 @@ var (
 	showHttpUrlFlag      bool
 	showInstanceUrlsFlag bool
 	showInstanceUrlFlag  string
+	showBranchesFlag     bool
 	paginationLimit      int
 	paginationCursor     string
 )

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -15,6 +15,8 @@ var (
 	showHttpUrlFlag      bool
 	showInstanceUrlsFlag bool
 	showInstanceUrlFlag  string
+	paginationLimit      int
+	paginationCursor     string
 )
 
 func getInstanceNames(client *turso.Client, dbName string) []string {

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -15,6 +15,8 @@ func init() {
 	dbCmd.AddCommand(listCmd)
 	listCmd.Flags().StringVarP(&groupFilter, "group", "g", "", "Filter databases by group")
 	listCmd.Flags().StringVarP(&schemaFilter, "schema", "s", "", "Filter databases by schema")
+	listCmd.Flags().IntVar(&paginationLimit, "limit", 0, "Limit the number of results returned")
+	listCmd.Flags().StringVar(&paginationCursor, "cursor", "", "Cursor for pagination")
 }
 
 var listCmd = &cobra.Command{
@@ -32,6 +34,8 @@ var listCmd = &cobra.Command{
 		options := turso.DatabaseListOptions{
 			Group:  groupFilter,
 			Schema: schemaFilter,
+			Limit:  paginationLimit,
+			Cursor: paginationCursor,
 		}
 		databases, err := client.Databases.List(options)
 		if err != nil {


### PR DESCRIPTION
Blocked until https://github.com/tursodatabase/turso/pull/2644 lands.

This PR adds listing branches with a new `--branches` flag for `db show`, and some updates to including pagination.

```bash
# List databases with a limit
turso db list --limit 10

# Get the next page of databases using the cursor
turso db list --cursor eyJmIjoiSUQiLCJ2IjoxMCwicyI6MTB9

# List branches with a limit
turso db show mydb --branches --limit 5

# Get the next page of branches
turso db show mydb --branches --cursor eyJmIjoiSUQiLCJ2IjoxMCwicyI6NX0
```