### PR TITLE
add AWS migration CLI command

### DIFF
--- a/internal/cmd/group_aws_migrate.go
+++ b/internal/cmd/group_aws_migrate.go
@@ -121,7 +121,7 @@ var groupAwsMigrationStartCmd = &cobra.Command{
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Millisecond)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 		defer cancel()
 
 		for {

--- a/internal/cmd/group_aws_migrate.go
+++ b/internal/cmd/group_aws_migrate.go
@@ -50,11 +50,13 @@ var groupAwsMigrationInfoCmd = &cobra.Command{
 		}
 
 		if info.Status == "pending" {
-			fmt.Printf("Migration is %v\n%v", internal.Emph("in progress"), info.Comment)
+			fmt.Printf("Migration is %v\n%v\n", internal.Emph("in progress"), info.Comment)
 		} else if info.Status == "finished" {
-			fmt.Printf("Migration is %v", internal.Emph("finished"))
+			fmt.Printf("Migration is %v\n", internal.Emph("finished"))
+		} else if info.Status == "aborted" {
+			fmt.Printf("Migration was %v\n", internal.Emph("aborted"))
 		} else if info.Status == "none" {
-			fmt.Printf("Migration is %v\n\n%v", internal.Emph("not started"), info.Comment)
+			fmt.Printf("Migration is %v\n", internal.Emph("not started"))
 		}
 
 		return nil
@@ -89,10 +91,13 @@ var groupAwsMigrationStartCmd = &cobra.Command{
 		}
 
 		if info.Status == "pending" {
-			fmt.Printf("Migration is %v\n%v", internal.Emph("in progress"), info.Comment)
+			fmt.Printf("Migration is %v\n%v\n", internal.Emph("in progress"), info.Comment)
 			return nil
 		} else if info.Status == "finished" {
-			fmt.Printf("Migration is %v", internal.Emph("finished"))
+			fmt.Printf("Migration is %v\n", internal.Emph("finished"))
+			return nil
+		} else if info.Status == "aborted" {
+			fmt.Printf("Migration was %v\nPlease, contact with support@turso.tech for further assistance with group migration\n", internal.Emph("aborted"))
 			return nil
 		}
 

--- a/internal/cmd/group_aws_migrate.go
+++ b/internal/cmd/group_aws_migrate.go
@@ -11,7 +11,7 @@ import (
 )
 
 var groupAwsMigrationCmd = &cobra.Command{
-	Use:   "migration",
+	Use:   "aws-migration",
 	Short: "Manage AWS migration of the group",
 }
 
@@ -50,13 +50,13 @@ var groupAwsMigrationInfoCmd = &cobra.Command{
 		}
 
 		if info.Status == "pending" {
-			fmt.Printf("Migration is %v\n%v\n", internal.Emph("in progress"), info.Comment)
+			fmt.Printf("AWS migration is %v\n%v\n", internal.Emph("in progress"), info.Comment)
 		} else if info.Status == "finished" {
-			fmt.Printf("Migration is %v\n", internal.Emph("finished"))
+			fmt.Printf("AWS migration is %v\n", internal.Emph("finished"))
 		} else if info.Status == "aborted" {
-			fmt.Printf("Migration was %v\n", internal.Emph("aborted"))
+			fmt.Printf("AWS migration was %v\n", internal.Emph("aborted"))
 		} else if info.Status == "none" {
-			fmt.Printf("Migration is %v\n", internal.Emph("not started"))
+			fmt.Printf("AWS migration is %v\n", internal.Emph("not started"))
 		}
 
 		return nil
@@ -65,7 +65,7 @@ var groupAwsMigrationInfoCmd = &cobra.Command{
 
 var groupAwsMigrationStartCmd = &cobra.Command{
 	Use:               "start <group-name>",
-	Short:             "Start migration process of the group",
+	Short:             "Start AWS migration process of the group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -91,13 +91,13 @@ var groupAwsMigrationStartCmd = &cobra.Command{
 		}
 
 		if info.Status == "pending" {
-			fmt.Printf("Migration is %v\n%v\n", internal.Emph("in progress"), info.Comment)
+			fmt.Printf("AWS migration is %v\n%v\n", internal.Emph("in progress"), info.Comment)
 			return nil
 		} else if info.Status == "finished" {
-			fmt.Printf("Migration is %v\n", internal.Emph("finished"))
+			fmt.Printf("AWS migration is %v\n", internal.Emph("finished"))
 			return nil
 		} else if info.Status == "aborted" {
-			fmt.Printf("Migration was %v\nPlease, contact with support@turso.tech for further assistance with group migration\n", internal.Emph("aborted"))
+			fmt.Printf("AWS migration was %v\nPlease, contact with support@turso.tech for further assistance with group migration\n", internal.Emph("aborted"))
 			return nil
 		}
 
@@ -113,7 +113,7 @@ var groupAwsMigrationStartCmd = &cobra.Command{
 			return nil
 		}
 
-		spinner := prompt.Spinner(fmt.Sprintf("Migration of group %v is in progress", group))
+		spinner := prompt.Spinner(fmt.Sprintf("AWS migration of group %v is in progress", group))
 		defer spinner.Stop()
 
 		err = client.Groups.StartAwsMigration(group)
@@ -121,14 +121,17 @@ var groupAwsMigrationStartCmd = &cobra.Command{
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Millisecond)
 		defer cancel()
 
 		for {
 			select {
 			case <-ctx.Done():
 				spinner.Stop()
-				fmt.Printf("Group %v migration still on-going\nCheck status few minutes later and contact support@turso.tech in case of any issues", internal.Emph(group))
+				fmt.Printf("AWS migration for group %v still on-going.\n\n"+
+					"You can check status of the migration with: `turso group migration info <group-name>`.\n"+
+					"If migrations for certain databases haven't started, you can abort the group migration with: `turso group migration abort <group-name>`.\n\n"+
+					"Contact support@turso.tech in case of any issues\n", internal.Emph(group))
 				return nil
 			case <-time.NewTimer(5 * time.Second).C:
 				info, err := client.Groups.GetAwsMigrationInfo(group)
@@ -149,7 +152,7 @@ var groupAwsMigrationStartCmd = &cobra.Command{
 
 var groupAwsMigrationAbortCmd = &cobra.Command{
 	Use:               "abort <group-name>",
-	Short:             "Abort migration process of the group",
+	Short:             "Abort AWS migration process of the group",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -175,13 +178,13 @@ var groupAwsMigrationAbortCmd = &cobra.Command{
 		}
 
 		if info.Status == "none" {
-			fmt.Printf("Migration is %v", internal.Emph("not started"))
+			fmt.Printf("AWS migration is %v", internal.Emph("not started"))
 			return nil
 		} else if info.Status == "aborted" {
-			fmt.Printf("Migration is already %v", internal.Emph("aborted"))
+			fmt.Printf("AWS migration was already %v", internal.Emph("aborted"))
 			return nil
 		} else if info.Status == "finished" {
-			fmt.Printf("Migration is already %v", internal.Emph("finished"))
+			fmt.Printf("AWS migration was already %v", internal.Emph("finished"))
 			return nil
 		}
 
@@ -195,7 +198,7 @@ var groupAwsMigrationAbortCmd = &cobra.Command{
 			return nil
 		}
 
-		spinner := prompt.Spinner(fmt.Sprintf("Migration of group %v aborted", group))
+		spinner := prompt.Spinner(fmt.Sprintf("AWS migration of group %v aborted", group))
 		defer spinner.Stop()
 
 		return client.Groups.AbortAwsMigration(group)

--- a/internal/cmd/group_aws_migrate.go
+++ b/internal/cmd/group_aws_migrate.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tursodatabase/turso-cli/internal"
+	"github.com/tursodatabase/turso-cli/internal/prompt"
+)
+
+var groupAwsMigrationCmd = &cobra.Command{
+	Use:   "migration",
+	Short: "Manage AWS migration of the group",
+}
+
+func init() {
+	groupCmd.AddCommand(groupAwsMigrationCmd)
+	groupAwsMigrationCmd.AddCommand(groupAwsMigrationInfoCmd)
+	groupAwsMigrationCmd.AddCommand(groupAwsMigrationStartCmd)
+}
+
+var groupAwsMigrationInfoCmd = &cobra.Command{
+	Use:               "info <group-name>",
+	Short:             "Migration status for the group",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		group := args[0]
+		if group == "" {
+			return fmt.Errorf("the first argument must contain a group name")
+		}
+
+		cmd.SilenceUsage = true
+		client, err := authedTursoClient()
+		if err != nil {
+			return err
+		}
+
+		_, err = client.Groups.Get(group)
+		if err != nil {
+			return err
+		}
+
+		info, err := client.Groups.GetAwsMigrationInfo(group)
+		if err != nil {
+			return err
+		}
+
+		if info.Status == "pending" {
+			fmt.Printf("Migration is %v\n%v", internal.Emph("in progress"), info.Comment)
+		} else if info.Status == "finished" {
+			fmt.Printf("Migration is %v", internal.Emph("finished"))
+		} else if info.Status == "none" {
+			fmt.Printf("Migration is %v\n\n%v", internal.Emph("not started"), info.Comment)
+		}
+
+		return nil
+	},
+}
+
+var groupAwsMigrationStartCmd = &cobra.Command{
+	Use:               "start <group-name>",
+	Short:             "Start migration process of the group",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		group := args[0]
+		if group == "" {
+			return fmt.Errorf("the first argument must contain a group name")
+		}
+
+		cmd.SilenceUsage = true
+		client, err := authedTursoClient()
+		if err != nil {
+			return err
+		}
+
+		_, err = client.Groups.Get(group)
+		if err != nil {
+			return err
+		}
+
+		info, err := client.Groups.GetAwsMigrationInfo(group)
+		if err != nil {
+			return err
+		}
+
+		if info.Status == "pending" {
+			fmt.Printf("Migration is %v\n%v", internal.Emph("in progress"), info.Comment)
+			return nil
+		} else if info.Status == "finished" {
+			fmt.Printf("Migration is %v", internal.Emph("finished"))
+			return nil
+		}
+
+		fmt.Printf("%v\n\n", info.Comment)
+
+		ok, err := promptConfirmation(fmt.Sprintf("Are you sure you want to migrate group %s from Fly to AWS?", internal.Emph(group)))
+		if err != nil {
+			return fmt.Errorf("could not get prompt confirmed by user: %w", err)
+		}
+
+		if !ok {
+			fmt.Println("Group migration cancelled by the user.")
+			return nil
+		}
+
+		spinner := prompt.Spinner(fmt.Sprintf("Migration of group %v is in progress", group))
+		defer spinner.Stop()
+
+		err = client.Groups.StartAwsMigration(group)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+		defer cancel()
+
+		for {
+			select {
+			case <-ctx.Done():
+				spinner.Stop()
+				fmt.Printf("Group %v migration still on-going\nCheck status few minutes later and contact support@turso.tech in case of any issues", internal.Emph(group))
+				return nil
+			case <-time.NewTimer(5 * time.Second).C:
+				info, err := client.Groups.GetAwsMigrationInfo(group)
+				if err != nil {
+					return err
+				}
+				if info.Status == "finished" {
+					spinner.Stop()
+					fmt.Printf("Group %v was successfully migrated from Fly to AWS", internal.Emph(group))
+					return nil
+				} else {
+					spinner.Text(info.Comment)
+				}
+			}
+		}
+	},
+}

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -420,6 +420,21 @@ func (d *GroupsClient) StartAwsMigration(group string) error {
 	return nil
 }
 
+func (d *GroupsClient) AbortAwsMigration(group string) error {
+	url := d.URL(fmt.Sprintf("/%s/aws/migration/abort", group))
+	r, err := d.client.Post(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to abort group migration: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		err := parseResponseError(r)
+		return fmt.Errorf("failed to start group migration: %w", err)
+	}
+	return nil
+}
+
 func (d *GroupsClient) URL(suffix string) string {
 	prefix := "/v1"
 	if d.client.Org != "" {

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -430,7 +430,7 @@ func (d *GroupsClient) AbortAwsMigration(group string) error {
 
 	if r.StatusCode != http.StatusOK {
 		err := parseResponseError(r)
-		return fmt.Errorf("failed to start group migration: %w", err)
+		return fmt.Errorf("failed to abort group migration: %w", err)
 	}
 	return nil
 }

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -381,6 +381,45 @@ func (d *GroupsClient) Transfer(group string, to string) error {
 	return nil
 }
 
+type AwsMigrationInfo struct {
+	Status  string `json:"status"`
+	Comment string `json:"comment"`
+}
+
+func (d *GroupsClient) GetAwsMigrationInfo(group string) (AwsMigrationInfo, error) {
+	url := d.URL(fmt.Sprintf("/%s/aws/migration/info", group))
+	r, err := d.client.Get(url, nil)
+	if err != nil {
+		return AwsMigrationInfo{}, fmt.Errorf("failed to get group migration info: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		err := parseResponseError(r)
+		return AwsMigrationInfo{}, fmt.Errorf("failed to get group migration info: %w", err)
+	}
+	result, err := unmarshal[AwsMigrationInfo](r)
+	if err != nil {
+		return AwsMigrationInfo{}, fmt.Errorf("failed to parse group migration info: %w", err)
+	}
+	return result, nil
+}
+
+func (d *GroupsClient) StartAwsMigration(group string) error {
+	url := d.URL(fmt.Sprintf("/%s/aws/migration/start", group))
+	r, err := d.client.Post(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to start group migration: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		err := parseResponseError(r)
+		return fmt.Errorf("failed to start group migration: %w", err)
+	}
+	return nil
+}
+
 func (d *GroupsClient) URL(suffix string) string {
 	prefix := "/v1"
 	if d.client.Org != "" {


### PR DESCRIPTION
Add two group level commands:
1. `turso group aws-migration info <group-name>` - shows status of the group migration process
2. `turso group aws-migration start <group-name>` - start migration process for selected group
3. `turso group aws-migration abort <group-name>` - abort migration process for selected group