### PR TITLE
Add `turso db export` command

### DIFF
--- a/internal/cmd/db_export.go
+++ b/internal/cmd/db_export.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var withMetadata bool
+var overwriteExport bool
+var outputFile string
+
+var exportCmd = &cobra.Command{
+	Use:   "export <database>",
+	Short: "Export a database snapshot from Turso to SQLite file.",
+	Long: `Export a database snapshot from Turso to SQLite file.
+
+This command exports a snapshot of the current generation of a Turso database
+to a local SQLite file.  Note that the exported file may not contain the
+latest changes. Use SDK to sync the database after exporting  to ensure you
+have the most recent version.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		dbName := args[0]
+		if outputFile == "" {
+			outputFile = dbName + ".db"
+		}
+		err := ExportDatabase(dbName, outputFile, withMetadata, overwriteExport)
+		if err != nil {
+			return fmt.Errorf("failed to export database: %w", err)
+		}
+		fmt.Printf("Exported database to %s\n", outputFile)
+		return nil
+	},
+}
+
+func ExportDatabase(dbName, outputFile string, withMetadata bool, overwrite bool) error {
+	if !overwrite {
+		if _, err := os.Stat(outputFile); err == nil {
+			return fmt.Errorf("file %s already exists, use `--overwrite` flag to overwrite it", outputFile)
+		}
+	}
+	client, err := authedTursoClient()
+	if err != nil {
+		return err
+	}
+	db, err := getDatabase(client, dbName)
+	if err != nil {
+		return fmt.Errorf("failed to find database: %w", err)
+	}
+	dbUrl := getDatabaseHttpUrl(&db)
+	err = client.Databases.Export(dbName, dbUrl, outputFile, withMetadata, overwrite)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	exportCmd.Flags().BoolVar(&withMetadata, "with-metadata", false, "Include metadata in the export.")
+	exportCmd.Flags().BoolVar(&overwriteExport, "overwrite", false, "Overwrite output file if it exists.")
+	exportCmd.Flags().StringVar(&outputFile, "output-file", "", "Specify the output file name (default: <database>.db)")
+	dbCmd.AddCommand(exportCmd)
+}


### PR DESCRIPTION
This adds a `turso db export` command, which exports a Turso database to
a local SQLite file. The export command does not generate a WAL file so
the database is a snapshot of time at the beginning of the current
generation, not the latest database version. You need to, therefore,
sync the database using Turso SDK if you need the latest data.

Example usage:

1. Export the `hello` database as `hello.db`:

```
turso db export hello
```

2. Overwrite an existing database file:

```
turso db export hello --overwrite
```

3. Generate metadata with the export:

```
turso db export hello --with-metadata
```

4. Output `hello` database to the `world.db` file:

```
turso db export hello --output-file world.db
```