### PR TITLE
Add Missing Completion Commands to the Allow List

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -38,6 +38,8 @@ func requiresLogin(cmd *cobra.Command) bool {
 		"turso config set token",
 		"turso update",
 		"turso completion",
+		"turso __complete",
+		"turso __completeNoDesc",
 		"turso db shell",
 		"turso dev",
 	}


### PR DESCRIPTION
This PR adds the two hidden completion commands to the unauthenticated allow list, to allow for users who haven't logged in to use the completion scripts.

## Context
Trying to use the completion (e.g. `turso<space><tab>`) before I was authenticated, led to a lot of unclear errors:

```fish
❯ turso math: Error: Unknown function
'ou are not logged in, please login with turso auth login before running other commands. / 1'
 ^^
math: Error: Unexpected token
'% 2'
  ^
test: Missing argument at index 3
-eq 1
      ^
/home/linuxbrew/.linuxbrew/share/fish/vendor_completions.d/turso.fish (line 94):
    if test $compErr -eq 1
       ^
in function '__turso_prepare_completions'
in command substitution
math: Error: Unknown function
'ou are not logged in, please login with turso auth login before running other commands. / 8'
 ^^
math: Error: Unexpected token
'% 2'
  ^
math: Error: Unknown function
'ou are not logged in, please login with turso auth login before running other commands. / 16'
 ^^
math: Error: Unexpected token
'% 2'
  ^
test: Missing argument at index 3
-eq 1
      ^
/home/linuxbrew/.linuxbrew/share/fish/vendor_completions.d/turso.fish (line 102):
    if test $filefilter -eq 1; or test $dirfilter -eq 1
       ^
in function '__turso_prepare_completions'
in command substitution
test: Missing argument at index 3
-eq 1
      ^
/home/linuxbrew/.linuxbrew/share/fish/vendor_completions.d/turso.fish (line 102):
    if test $filefilter -eq 1; or test $dirfilter -eq 1
                                  ^
in function '__turso_prepare_completions'
in command substitution
math: Error: Unknown function
'ou are not logged in, please login with turso auth login before running other commands. / 2'
 ^^
math: Error: Unexpected token
'% 2'
  ^
math: Error: Unknown function
'ou are not logged in, please login with turso auth login before running other commands. / 4'
 ^^
math: Error: Unexpected token
'% 2'
  ^
test: Missing argument at index 3
-ne 0
      ^
/home/linuxbrew/.linuxbrew/share/fish/vendor_completions.d/turso.fish (line 118):
    if test $nospace -ne 0; or test $nofiles -eq 0
       ^
in function '__turso_prepare_completions'
in command substitution
test: Missing argument at index 3
-eq 0
      ^
/home/linuxbrew/.linuxbrew/share/fish/vendor_completions.d/turso.fish (line 118):
    if test $nospace -ne 0; or test $nofiles -eq 0
                               ^
in function '__turso_prepare_completions'
in command substitution
tu
```

But they all pointed to the completion script and not being authenticated. So having a look at the script, I saw it was calling a `__complete` command to produce the completion results:

```fish
    # Disable ActiveHelp which is not supported for fish shell
    set -l requestComp "TURSO_ACTIVE_HELP=0 $args[1] __complete $args[2..-1] $lastArg"
```

Finally, some digging showed these commands were produced by [cobra](https://github.com/spf13/cobra) and included `__completeNoDesc` and there already was an allow list for unauthenticated commands, so I just added them there.

### To Reproduce:
You just need to log out if you're logged in and try to use the completion. I'm using fish, but this should apply to bash and zsh with some variation for the errors.