### PR TITLE
Fix version in `turso group list` output

### DIFF
--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -221,7 +221,11 @@ func destroyGroup(client *turso.Client, name string) error {
 func groupsTable(groups []turso.Group) [][]string {
 	var data [][]string
 	for _, group := range groups {
-		row := []string{group.Name, formatLocations(group.Locations, group.Primary), group.Version, aggregateGroupStatus(group)}
+		version := "turso-server"
+		if group.Version != "tech-preview" {
+			version = group.Version
+		}
+		row := []string{group.Name, formatLocations(group.Locations, group.Primary), version, aggregateGroupStatus(group)}
 		data = append(data, row)
 	}
 	return data


### PR DESCRIPTION
The `tech-preview` version is just something the API returns for historical reasons. Therefore, output "turso-server" instead to avoid confusing people.