### PR TITLE
internal/cmd/root.go: Handle error when adding reset config flag

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -112,7 +112,10 @@ func init() {
 	}
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	flags.AddDebugFlag(rootCmd)
-	flags.AddResetConfigFlag(rootCmd)
+	err := flags.AddResetConfigFlag(rootCmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error adding reset config flag: %s", err)
+	}
 }
 
 func VerifyUserIsLoggedIn() {

--- a/internal/flags/config.go
+++ b/internal/flags/config.go
@@ -6,9 +6,12 @@ import (
 
 var resetConfig bool
 
-func AddResetConfigFlag(cmd *cobra.Command) {
+func AddResetConfigFlag(cmd *cobra.Command) error {
 	cmd.PersistentFlags().BoolVar(&resetConfig, "reset-config", false, "")
-	cmd.PersistentFlags().MarkHidden("reset-config")
+	if err := cmd.PersistentFlags().MarkHidden("reset-config"); err != nil {
+		return err
+	}
+	return nil
 }
 
 func ResetConfig() bool {


### PR DESCRIPTION
Refactored AddResetConfigFlag to return an error and updated its usage in root.go to handle potential errors when marking the flag as hidden.

internal/flags/config: refactor accordingly