### PR TITLE
Allow connecting local dbs just by name

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -40,6 +40,11 @@ func getURL(db *turso.Database, client *turso.Client, http bool, primaryOnly boo
 		scheme = "https"
 	}
 
+	if isLocalDevelopmentDb(db) {
+		// for locally running dbs, we fallback to http scheme
+		scheme = "http"
+	}
+
 	if instanceFlag == "" && locationFlag == "" {
 		if !primaryOnly {
 			return getUrl(db, nil, scheme), nil

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -87,7 +87,11 @@ func getInstanceUrl(db *turso.Database, inst *turso.Instance) string {
 }
 
 func getDatabaseHttpUrl(db *turso.Database) string {
-	return getUrl(db, nil, "https")
+	scheme := "https"
+	if isLocalDevelopmentDb(db) {
+		scheme = "http"
+	}
+	return getUrl(db, nil, scheme)
 }
 
 func getUrl(db *turso.Database, inst *turso.Instance, scheme string) string {
@@ -371,4 +375,9 @@ func isInteractive() bool {
 
 func isTerminal(f *os.File) bool {
 	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}
+
+// isLocalDevelopmentDb checks if the db is running on a local server.
+func isLocalDevelopmentDb(db *turso.Database) bool {
+	return db.PrimaryRegion == "local"
 }


### PR DESCRIPTION
Currently, if I am connecting to a local db server, I need to specify the full URL:

```
turso db shell http://sunny-doomsday-local-user.localhost:9090
```

if I just specify the name, I get an error:

```
turso db shell sunny-doomsday

Error: failed to connect to database. err: failed to execute SQL:
Post "https://sunny-doomsday-local-user.localhost:9090/v2/pipeline": http: server gave HTTP response to HTTPS client
exit status 1
```

so to fix this, if we find the db to be running locally, then we fallback to http and then we can connect to the local dbs just by the name