### PR TITLE
Make it possible to reset baseUrl

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/tursodatabase/turso-cli/internal"
@@ -255,10 +256,12 @@ func deleteDatabaseInstance(client *turso.Client, database, instance string) err
 
 func getTursoUrl() string {
 	config, _ := settings.ReadSettings() // ok to ignore, we'll fallback to default
+	viper.AllowEmptyEnv(true)
 	url := config.GetBaseURL()
 	if url == "" {
 		url = tursoDefaultBaseURL
 	}
+	viper.AllowEmptyEnv(false)
 	return url
 }
 


### PR DESCRIPTION
This PR makes it possible to reset the CLI's base url by setting `TURSO_API_BASEURL`. I think this was the original intent, but it wasn't working, because the existing config file was overriding the empty environment variable.