### PR TITLE
Allow forking without the group flag

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -100,7 +100,7 @@ func CreateDatabase(name string) error {
 	var group turso.Group
 
 	if fromDBFlag != "" {
-		seed, err = parseDBSeedFlags(client, false, "")
+		seed, err = parseDBSeedFlags(client, false, "", false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes [#1004](https://github.com/tursodatabase/turso-cli/issues/1004)

From what I understand (could be mistaken, first timer here): we should allow `turso db create --from-db somedb` even if user has multiple groups and hasn't specified one. The created DB will be within the same group of the seed DB.

We also check if a group was specified anyway then it should match the seed DB's group.