### PR TITLE
Support encryption flags on db import command

### DIFF
--- a/internal/cmd/db_import.go
+++ b/internal/cmd/db_import.go
@@ -13,6 +13,8 @@ var multipartFlag bool
 func init() {
 	dbCmd.AddCommand(importCmd)
 	addGroupFlag(importCmd)
+	addRemoteEncryptionKeyFlag(importCmd)
+	addRemoteEncryptionCipherFlag(importCmd)
 	importCmd.Flags().BoolVar(&multipartFlag, "multipart", false, "force multipart upload")
 }
 


### PR DESCRIPTION
I had missed this earlier. This lil patch adds support for encryption flags to `db import` cmd: 

```
$ turso db import my-local-file.db --remote-encryption-key "gq2Lq...DPOY=" --remote-encryption-cipher aegis256
```