### PR TITLE
use fork of sqlclosecheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,8 @@ jobs:
         run: go vet -v ./...
 
       - name: Install sqlclosecheck
-        run: go install github.com/ryanrolds/sqlclosecheck@latest
+        # TODO revert to github.com/ryanrolds/sqlclosecheck when https://github.com/ryanrolds/sqlclosecheck/pull/47 is merged
+        run: go install github.com/LeMikaelF/sqlclosecheck@1da86b1d3e6944a00c18d525f2dfba006f4cbd6c
 
       - name: sqlclosecheck
         run: go vet -vettool=${HOME}/go/bin/sqlclosecheck ./...


### PR DESCRIPTION
In https://github.com/tursodatabase/turso-cli/pull/1012, I'm updating the Go version to 1.25 to be able to use the experimental `synctest` package, but one of our linters isn't compatible. 

I opened a PR (linked in the code), but I don't want to have to wait for the maintainer (there's a PR that's 2 weeks old with no comments). So this PR uses my fork instead.