### PR TITLE
Upgrade forked sqlclosecheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install sqlclosecheck
         # TODO revert to github.com/ryanrolds/sqlclosecheck when https://github.com/ryanrolds/sqlclosecheck/pull/47 is merged
-        run: go install github.com/LeMikaelF/sqlclosecheck@1da86b1d3e6944a00c18d525f2dfba006f4cbd6c
+        run: go install github.com/LeMikaelF/sqlclosecheck@b53ecaccb94623dfa6050e4ada4eeecd3a130829
 
       - name: sqlclosecheck
         run: go vet -vettool=${HOME}/go/bin/sqlclosecheck ./...


### PR DESCRIPTION
In my previous PR (https://github.com/tursodatabase/turso-cli/pull/1014), I changed `sqlclosecheck` to point to my fork, because of a compatibility issue, but I made a mistake and the commit on my fork was unusable.

Before:

```
$> go install github.com/LeMikaelF/sqlclosecheck@1da86b1d3e6944a00c18d525f2dfba006f4cbd6c
go: downloading github.com/LeMikaelF/sqlclosecheck v0.0.0-20260108222604-1da86b1d3e69
go: github.com/LeMikaelF/sqlclosecheck@1da86b1d3e6944a00c18d525f2dfba006f4cbd6c: version constraints conflict:
        github.com/LeMikaelF/sqlclosecheck@v0.0.0-20260108222604-1da86b1d3e69: parsing go.mod:
        module declares its path as: github.com/ryanrolds/sqlclosecheck
                but was required as: github.com/LeMikaelF/sqlclosecheck
```

After:

```
$> go install github.com/LeMikaelF/sqlclosecheck@b53ecaccb94623dfa6050e4ada4eeecd3a130829
go: finding module for package github.com/ryanrolds/sqlclosecheck/pkg/analyzer
go: found github.com/ryanrolds/sqlclosecheck/pkg/analyzer in github.com/ryanrolds/sqlclosecheck v0.5.1
$> go vet -vettool=${HOME}/go/bin/sqlclosecheck ./...
```