### PR TITLE
fix: explicitly use -list now that sqlite3 defaults to table output

### DIFF
--- a/internal/cmd/db_create_test.go
+++ b/internal/cmd/db_create_test.go
@@ -230,7 +230,7 @@ func TestGetReservedBytes(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
-	cmd := exec.Command("sqlite3", dbPath, "CREATE TABLE test (id INTEGER);")
+	cmd := exec.Command("sqlite3", "-list", dbPath, "CREATE TABLE test (id INTEGER);")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to create test database: %v", err)
 	}
@@ -255,12 +255,12 @@ func TestValidateReservedBytesAllCiphers(t *testing.T) {
 			tmpDir := t.TempDir()
 			dbPath := filepath.Join(tmpDir, "test.db")
 
-			cmd := exec.Command("sqlite3", dbPath, "CREATE TABLE test (id INTEGER);")
+			cmd := exec.Command("sqlite3", "-list", dbPath, "CREATE TABLE test (id INTEGER);")
 			if err := cmd.Run(); err != nil {
 				t.Fatalf("failed to create test database: %v", err)
 			}
 
-			cmd = exec.Command("sqlite3", dbPath,
+			cmd = exec.Command("sqlite3", "-list", dbPath,
 				fmt.Sprintf(".filectrl reserve_bytes %d", expectedBytes),
 				"VACUUM;")
 			if err := cmd.Run(); err != nil {
@@ -300,12 +300,12 @@ func TestCipherReservedBytesCrossValidation(t *testing.T) {
 			tmpDir := t.TempDir()
 			dbPath := filepath.Join(tmpDir, "test.db")
 
-			cmd := exec.Command("sqlite3", dbPath, "CREATE TABLE test (id INTEGER);")
+			cmd := exec.Command("sqlite3", "-list", dbPath, "CREATE TABLE test (id INTEGER);")
 			if err := cmd.Run(); err != nil {
 				t.Fatalf("failed to create test database: %v", err)
 			}
 
-			cmd = exec.Command("sqlite3", dbPath,
+			cmd = exec.Command("sqlite3", "-list", dbPath,
 				fmt.Sprintf(".filectrl reserve_bytes %d", tt.wrongBytes),
 				"VACUUM;")
 			if err := cmd.Run(); err != nil {

--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -222,7 +222,7 @@ func checkIfDump(filename string) (bool, error) {
 
 // getReservedBytes retrieves the current reserved bytes setting from a SQLite database
 func getReservedBytes(dbPath string) (int, error) {
-	output, err := exec.Command("sqlite3", dbPath, ".filectrl reserve_bytes").CombinedOutput()
+	output, err := exec.Command("sqlite3", "-list", dbPath, ".filectrl reserve_bytes").CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get reserved bytes: %w", err)
 	}
@@ -295,7 +295,7 @@ func sqliteFileIntegrityChecks(file string, cipher string) error {
 	if flags.Debug() {
 		log.Printf("Checking database settings...")
 	}
-	output, err := exec.Command("sqlite3", file, ".mode line",
+	output, err := exec.Command("sqlite3", "-list", file, ".mode line",
 		"select journal_mode as j, page_size as p, auto_vacuum as a, encoding as e from pragma_journal_mode, pragma_page_size, pragma_auto_vacuum, pragma_encoding;").CombinedOutput()
 	if err != nil {
 
@@ -340,7 +340,7 @@ func sqliteFileIntegrityChecks(file string, cipher string) error {
 }
 
 func runQuickCheck(file string) error {
-	cmd := exec.Command("sqlite3", file, "pragma quick_check;")
+	cmd := exec.Command("sqlite3", "-list", file, "pragma quick_check;")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("integrity check failed: %w", err)
 	}
@@ -405,7 +405,7 @@ func checkSQLiteAvailable() error {
 }
 
 func checkSQLiteFile(file string) error {
-	output, err := exec.Command("sqlite3", file, "pragma quick_check;").CombinedOutput()
+	output, err := exec.Command("sqlite3", "-list", file, "pragma quick_check;").CombinedOutput()
 
 	execErr := &exec.ExitError{}
 	if errors.As(err, &execErr) && execErr.ExitCode() == 26 {
@@ -428,7 +428,7 @@ func createTempFile() (*os.File, error) {
 
 func dumpSQLiteDatabase(database string, dump *os.File) error {
 	stdErr := &bytes.Buffer{}
-	cmd := exec.Command("sqlite3", database, ".dump")
+	cmd := exec.Command("sqlite3", "-list", database, ".dump")
 	cmd.Stdout = dump
 	cmd.Stderr = stdErr
 

--- a/internal/cmd/group_flag_test.go
+++ b/internal/cmd/group_flag_test.go
@@ -22,7 +22,7 @@ func createTestDatabase(t *testing.T, sizeBytes int) string {
 	dbPath := filepath.Join(tmpDir, "test.db")
 
 	// Create database with correct settings for Turso
-	cmd := exec.Command("sqlite3", dbPath,
+	cmd := exec.Command("sqlite3", "-list", dbPath,
 		"PRAGMA page_size=4096;",
 		"PRAGMA journal_mode=WAL;",
 		"CREATE TABLE data (id INTEGER PRIMARY KEY, blob BLOB);")
@@ -36,7 +36,7 @@ func createTestDatabase(t *testing.T, sizeBytes int) string {
 			numRows = 1
 		}
 		for i := 0; i < numRows; i++ {
-			cmd = exec.Command("sqlite3", dbPath,
+			cmd = exec.Command("sqlite3", "-list", dbPath,
 				fmt.Sprintf("INSERT INTO data (blob) VALUES (randomblob(%d));", rowSize))
 			require.NoError(t, cmd.Run())
 		}


### PR DESCRIPTION
the newest sqlite3 CLI release outputs `table` view by default, breaking our parsing expectations. This PR fixes this