### PR TITLE
use db-api v3 for certain operations

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -18,7 +18,6 @@ import (
 	"github.com/tursodatabase/turso-cli/internal"
 	"github.com/tursodatabase/turso-cli/internal/flags"
 	"github.com/tursodatabase/turso-cli/internal/settings"
-	"github.com/tursodatabase/turso-cli/internal/turso"
 )
 
 //go:embed login.html
@@ -277,8 +276,8 @@ func signupHint(config *settings.Settings) {
 		return
 	}
 
-	r, err := client.Databases.List(turso.DatabaseListOptions{})
-	if err != nil || len(r.Databases) != 0 {
+	databases, err := listDatabases(client)
+	if err != nil || len(databases) != 0 {
 		return
 	}
 

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
+	"github.com/tursodatabase/turso-cli/internal/flags"
 	"github.com/tursodatabase/turso-cli/internal/settings"
 	"github.com/tursodatabase/turso-cli/internal/turso"
 )
@@ -38,6 +39,21 @@ func extractDatabaseNames(databases []turso.Database) []string {
 	return names
 }
 
+func getDatabaseConfig(client *turso.Client, name string, fresh ...bool) (turso.DatabaseConfig, error) {
+	if !flags.V3Api() {
+		return client.Databases.GetConfig(name)
+	}
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return turso.DatabaseConfig{}, err
+	}
+	dbID, err := tryResolveDbID(client, name)
+	if err != nil {
+		return turso.DatabaseConfig{}, err
+	}
+	return client.DatabasesV3.GetConfig(orgID, dbID)
+}
+
 func getDatabase(client *turso.Client, name string, fresh ...bool) (turso.Database, error) {
 	databases, err := getDatabases(client, fresh...)
 	if err != nil {
@@ -53,17 +69,40 @@ func getDatabase(client *turso.Client, name string, fresh ...bool) (turso.Databa
 	return turso.Database{}, fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(name), internal.Emph("turso db list"))
 }
 
+func listDatabases(client *turso.Client) ([]turso.Database, error) {
+	if !flags.V3Api() {
+		return listDatabasesV2(client)
+	}
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return nil, err
+	}
+	if orgID == "" {
+		return listDatabasesV2(client)
+	}
+	databases, _, err := client.DatabasesV3.List(orgID, turso.DatabaseV3ListOptions{})
+	return databases, err
+}
+
+func listDatabasesV2(client *turso.Client) ([]turso.Database, error) {
+	response, err := client.Databases.List(turso.DatabaseListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return response.Databases, err
+}
+
 func getDatabases(client *turso.Client, fresh ...bool) ([]turso.Database, error) {
 	skipCache := len(fresh) > 0 && fresh[0]
 	if cachedNames := getDatabasesCache(); !skipCache && cachedNames != nil {
 		return cachedNames, nil
 	}
-	r, err := client.Databases.List(turso.DatabaseListOptions{})
+	databases, err := listDatabases(client)
 	if err != nil {
 		return nil, err
 	}
-	setDatabasesCache(r.Databases)
-	return r.Databases, nil
+	setDatabasesCache(databases)
+	return databases, nil
 }
 
 func getDatabasesMap(client *turso.Client, fresh bool) (map[string]turso.Database, error) {

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -39,7 +39,7 @@ func extractDatabaseNames(databases []turso.Database) []string {
 	return names
 }
 
-func getDatabaseConfig(client *turso.Client, name string, fresh ...bool) (turso.DatabaseConfig, error) {
+func getDatabaseConfig(client *turso.Client, name string) (turso.DatabaseConfig, error) {
 	if !flags.V3Api() {
 		return client.Databases.GetConfig(name)
 	}

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -158,9 +158,6 @@ func createDatabase(client *turso.Client, name, location, groupName string, seed
 	if seed != nil && seed.Type != "database" && seed.Type != "upload" {
 		return createDatabaseV2(client, name, location, groupName, seed, spinner)
 	}
-	if flags.V3Api() {
-		_, _ = getGroups(client, true)
-	}
 	orgID, err := tryResolveOrgID(client)
 	if err != nil {
 		return err

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -92,7 +92,7 @@ func CreateDatabase(name string) error {
 		return err
 	}
 
-	groups, err := client.Groups.List()
+	groups, err := listGroups(client)
 	if err != nil {
 		return err
 	}
@@ -157,6 +157,9 @@ func createDatabase(client *turso.Client, name, location, groupName string, seed
 	}
 	if seed != nil && seed.Type != "database" && seed.Type != "upload" {
 		return createDatabaseV2(client, name, location, groupName, seed, spinner)
+	}
+	if flags.V3Api() {
+		_, _ = getGroups(client, true)
 	}
 	orgID, err := tryResolveOrgID(client)
 	if err != nil {

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -127,7 +127,7 @@ func CreateDatabase(name string) error {
 	spinner := prompt.Spinner(fmt.Sprintf("Creating database %s in group %s...", internal.Emph(name), internal.Emph(groupName)))
 	defer spinner.Stop()
 
-	if _, err = client.Databases.Create(name, location, "", "", groupName, schemaFlag, typeFlag == "schema", seed, sizeLimitFlag, remoteEncryptionCipherFlag, remoteEncryptionKeyFlag(), tursoDBFlag, spinner); err != nil {
+	if err := createDatabase(client, name, location, groupName, seed, spinner); err != nil {
 		return fmt.Errorf("could not create database %s: %w", name, err)
 	}
 
@@ -143,6 +143,78 @@ func CreateDatabase(name string) error {
 	fmt.Printf("   %s\n\n", internal.Emph("turso db tokens create "+name))
 	invalidateDatabasesCache()
 	return nil
+}
+
+func createDatabase(client *turso.Client, name, location, groupName string, seed *turso.DBSeed, spinner *prompt.SpinnerT) error {
+	if !flags.V3Api() {
+		return createDatabaseV2(client, name, location, groupName, seed, spinner)
+	}
+	if schemaFlag != "" || typeFlag == "schema" {
+		return createDatabaseV2(client, name, location, groupName, seed, spinner)
+	}
+	if sizeLimitFlag != "" {
+		return createDatabaseV2(client, name, location, groupName, seed, spinner)
+	}
+	if seed != nil && seed.Type != "database" && seed.Type != "upload" {
+		return createDatabaseV2(client, name, location, groupName, seed, spinner)
+	}
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return err
+	}
+	if orgID == "" {
+		return createDatabaseV2(client, name, location, groupName, seed, spinner)
+	}
+	body := CreateDatabaseV3BodyFromFlags(name, seed)
+	if seed == nil || seed.Type != "database" {
+		groupID, err := tryResolveGroupID(client, groupName)
+		if err != nil {
+			return err
+		}
+		if groupID == "" {
+			return createDatabaseV2(client, name, location, groupName, seed, spinner)
+		}
+		body.GroupID = groupID
+	} else if seed.Type == "database" {
+		_, err := client.DatabasesV3.Create(orgID, body)
+		return err
+	}
+	_, err = client.DatabasesV3.Create(orgID, body)
+	return err
+}
+
+func createDatabaseV2(client *turso.Client, name, location, groupName string, seed *turso.DBSeed, spinner *prompt.SpinnerT) error {
+	_, err := client.Databases.Create(name, location, "", "", groupName, schemaFlag, typeFlag == "schema", seed, sizeLimitFlag, remoteEncryptionCipherFlag, remoteEncryptionKeyFlag(), tursoDBFlag, spinner)
+	return err
+}
+
+func CreateDatabaseV3BodyFromFlags(name string, seed *turso.DBSeed) turso.CreateDatabaseV3Body {
+	body := turso.CreateDatabaseV3Body{
+		Name:         name,
+		CreationMode: "empty",
+	}
+	if tursoDBFlag {
+		body.DatabaseType = "tursodb"
+	} else {
+		body.DatabaseType = "libsql"
+	}
+	if seed != nil && seed.Type == "database" {
+		body.CreationMode = "fork"
+		body.ParentDBName = seed.Name
+		if seed.Timestamp != nil {
+			body.Timestamp = seed.Timestamp
+		}
+	}
+	if seed != nil && seed.Type == "upload" {
+		body.CreationMode = "upload"
+	}
+	if remoteEncryptionKeyFlag() != "" {
+		body.RemoteEncryption = &turso.RemoteEncryption{
+			EncryptionKey:    remoteEncryptionKeyFlag(),
+			EncryptionCipher: remoteEncryptionCipherFlag,
+		}
+	}
+	return body
 }
 
 func ensureGroup(client *turso.Client, group string, groups []turso.Group, location, version string) error {

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -78,16 +78,16 @@ func getToken(
 	fineGrainedPermissions []flags.FineGrainedPermissions,
 ) (string, error) {
 	if group {
-		if group && database.Group == "" {
+		if database.Group == "" {
 			return "", errors.New("--group flag can only be set with group databases")
 		}
 		return client.Groups.Token(database.Group, expiration, readOnly, claim, fineGrainedPermissions)
 	}
 	if !flags.V3Api() {
-		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
+		return getTokenV2(client, database, expiration, readOnly, claim, fineGrainedPermissions)
 	}
 	if claim != nil {
-		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
+		return getTokenV2(client, database, expiration, readOnly, claim, fineGrainedPermissions)
 	}
 	orgID, err := tryResolveOrgID(client)
 	if err != nil {
@@ -95,7 +95,7 @@ func getToken(
 	}
 	dbID := database.ID
 	if orgID == "" || dbID == "" {
-		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
+		return getTokenV2(client, database, expiration, readOnly, claim, fineGrainedPermissions)
 	}
 	return client.DatabasesV3.Token(orgID, dbID, expiration, readOnly, fineGrainedPermissions)
 }
@@ -104,12 +104,9 @@ func getTokenV2(
 	client *turso.Client,
 	database turso.Database,
 	expiration string,
-	readOnly, group bool,
+	readOnly bool,
 	claim *turso.PermissionsClaim,
 	fineGrainedPermissions []flags.FineGrainedPermissions,
 ) (string, error) {
-	if group && database.Group == "" {
-		return "", errors.New("--group flag can only be set with group databases")
-	}
-	return client.Groups.Token(database.Group, expiration, readOnly, claim, fineGrainedPermissions)
+	return client.Databases.Token(database.Name, expiration, readOnly, claim, fineGrainedPermissions)
 }

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -77,9 +77,31 @@ func getToken(
 	claim *turso.PermissionsClaim,
 	fineGrainedPermissions []flags.FineGrainedPermissions,
 ) (string, error) {
-	if !group {
-		return client.Databases.Token(database.Name, expiration, readOnly, claim, fineGrainedPermissions)
+	if !flags.V3Api() {
+		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
 	}
+	if claim != nil || group {
+		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
+	}
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return "", err
+	}
+	dbID := database.ID
+	if orgID == "" || dbID == "" {
+		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
+	}
+	return client.DatabasesV3.Token(orgID, dbID, expiration, readOnly, fineGrainedPermissions)
+}
+
+func getTokenV2(
+	client *turso.Client,
+	database turso.Database,
+	expiration string,
+	readOnly, group bool,
+	claim *turso.PermissionsClaim,
+	fineGrainedPermissions []flags.FineGrainedPermissions,
+) (string, error) {
 	if group && database.Group == "" {
 		return "", errors.New("--group flag can only be set with group databases")
 	}

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -77,10 +77,16 @@ func getToken(
 	claim *turso.PermissionsClaim,
 	fineGrainedPermissions []flags.FineGrainedPermissions,
 ) (string, error) {
+	if group {
+		if group && database.Group == "" {
+			return "", errors.New("--group flag can only be set with group databases")
+		}
+		return client.Groups.Token(database.Group, expiration, readOnly, claim, fineGrainedPermissions)
+	}
 	if !flags.V3Api() {
 		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
 	}
-	if claim != nil || group {
+	if claim != nil {
 		return getTokenV2(client, database, expiration, readOnly, group, claim, fineGrainedPermissions)
 	}
 	orgID, err := tryResolveOrgID(client)

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -62,7 +62,7 @@ var dbGenerateTokenCmd = &cobra.Command{
 		}
 		token, err := getToken(client, database, expiration, flags.ReadOnly(), groupTokenFlag, claim, permissions)
 		if err != nil {
-			return errors.New("your database does not support token generation")
+			return fmt.Errorf("failed to generate database token: %v", err)
 		}
 		fmt.Println(token)
 		return nil

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
-	"github.com/tursodatabase/turso-cli/internal"
 	"github.com/tursodatabase/turso-cli/internal/turso"
 )
 
@@ -55,11 +54,6 @@ var dbInspectCmd = &cobra.Command{
 		fmt.Printf("Number of rows written: %d\n", dbUsage.Usage.RowsWritten)
 		if dbUsage.Usage.BytesSynced != 0 {
 			fmt.Printf("Embedded syncs: %s\n", humanize.Bytes(dbUsage.Usage.BytesSynced))
-		}
-
-		if len(instances) == 0 {
-			fmt.Printf("\n🛠 Run %s to finish your database creation!\n", internal.Emph("turso db replicate "+db.Name))
-			return nil
 		}
 
 		if !verboseFlag {

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -47,17 +47,6 @@ func (df *DatabaseFetcher) FetchPage(pageSize int, cursor *string) (turso.ListRe
 		}
 		groupID = id
 	}
-	parentDbId := ""
-	if df.ParentDbId != "" {
-		id, err := tryResolveDbID(df.client, df.ParentDbId)
-		if err != nil {
-			return turso.ListResponse{}, err
-		}
-		if id == "" {
-			return df.fetchPageV2(pageSize, cursor)
-		}
-		parentDbId = id
-	}
 	cursorStr := ""
 	if cursor != nil {
 		cursorStr = *cursor
@@ -66,7 +55,7 @@ func (df *DatabaseFetcher) FetchPage(pageSize int, cursor *string) (turso.ListRe
 		GroupId:    groupID,
 		Limit:      pageSize,
 		Cursor:     cursorStr,
-		ParentDbId: parentDbId,
+		ParentDbId: df.ParentDbId,
 	}
 	dbs, err := df.client.DatabasesV3.List(orgID, options)
 	if err != nil {

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -20,6 +20,7 @@ type DatabaseFetcher struct {
 	SchemaFilter string
 	GroupFilter  string
 	ParentDbId   string
+	LoadFullInfo bool
 }
 
 func (df *DatabaseFetcher) FetchPage(pageSize int, cursor *string) (turso.ListResponse, error) {
@@ -65,6 +66,14 @@ func (df *DatabaseFetcher) FetchPage(pageSize int, cursor *string) (turso.ListRe
 	if next != "" {
 		response.Pagination = &turso.Pagination{Next: &next}
 	}
+	if df.LoadFullInfo {
+		for i := range response.Databases {
+			response.Databases[i], err = df.client.DatabasesV3.Get(orgID, response.Databases[i].ID)
+			if err != nil {
+				return turso.ListResponse{}, err
+			}
+		}
+	}
 	return response, nil
 }
 
@@ -79,9 +88,22 @@ func (df *DatabaseFetcher) fetchPageV2(pageSize int, cursor *string) (turso.List
 		Schema: schemaFilter,
 		Limit:  pageSize,
 		Cursor: cursorStr,
+		Parent: df.ParentDbId,
 	}
 
-	return df.client.Databases.List(options)
+	response, err := df.client.Databases.List(options)
+	if err != nil {
+		return turso.ListResponse{}, err
+	}
+	if df.LoadFullInfo {
+		for i := range response.Databases {
+			response.Databases[i], err = df.client.Databases.Get(response.Databases[i].Name)
+			if err != nil {
+				return turso.ListResponse{}, err
+			}
+		}
+	}
+	return response, nil
 }
 
 var listCmd = &cobra.Command{

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -57,11 +57,15 @@ func (df *DatabaseFetcher) FetchPage(pageSize int, cursor *string) (turso.ListRe
 		Cursor:     cursorStr,
 		ParentDbId: df.ParentDbId,
 	}
-	dbs, err := df.client.DatabasesV3.List(orgID, options)
+	dbs, next, err := df.client.DatabasesV3.List(orgID, options)
 	if err != nil {
 		return turso.ListResponse{}, err
 	}
-	return turso.ListResponse{Databases: dbs}, nil
+	response := turso.ListResponse{Databases: dbs}
+	if next != "" {
+		response.Pagination = &turso.Pagination{Next: &next}
+	}
+	return response, nil
 }
 
 func (df *DatabaseFetcher) fetchPageV2(pageSize int, cursor *string) (turso.ListResponse, error) {

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/tursodatabase/turso-cli/internal/flags"
 	"github.com/tursodatabase/turso-cli/internal/turso"
 )
 
@@ -15,10 +16,66 @@ func init() {
 }
 
 type DatabaseFetcher struct {
-	client *turso.Client
+	client       *turso.Client
+	SchemaFilter string
+	GroupFilter  string
+	ParentDbId   string
 }
 
 func (df *DatabaseFetcher) FetchPage(pageSize int, cursor *string) (turso.ListResponse, error) {
+	if !flags.V3Api() {
+		return df.fetchPageV2(pageSize, cursor)
+	}
+	if df.SchemaFilter != "" {
+		return df.fetchPageV2(pageSize, cursor)
+	}
+	orgID, err := tryResolveOrgID(df.client)
+	if err != nil {
+		return turso.ListResponse{}, err
+	}
+	if orgID == "" {
+		return df.fetchPageV2(pageSize, cursor)
+	}
+	groupID := ""
+	if df.GroupFilter != "" {
+		id, err := tryResolveGroupID(df.client, df.GroupFilter)
+		if err != nil {
+			return turso.ListResponse{}, err
+		}
+		if id == "" {
+			return df.fetchPageV2(pageSize, cursor)
+		}
+		groupID = id
+	}
+	parentDbId := ""
+	if df.ParentDbId != "" {
+		id, err := tryResolveDbID(df.client, df.ParentDbId)
+		if err != nil {
+			return turso.ListResponse{}, err
+		}
+		if id == "" {
+			return df.fetchPageV2(pageSize, cursor)
+		}
+		parentDbId = id
+	}
+	cursorStr := ""
+	if cursor != nil {
+		cursorStr = *cursor
+	}
+	options := turso.DatabaseV3ListOptions{
+		GroupId:    groupID,
+		Limit:      pageSize,
+		Cursor:     cursorStr,
+		ParentDbId: parentDbId,
+	}
+	dbs, err := df.client.DatabasesV3.List(orgID, options)
+	if err != nil {
+		return turso.ListResponse{}, err
+	}
+	return turso.ListResponse{Databases: dbs}, nil
+}
+
+func (df *DatabaseFetcher) fetchPageV2(pageSize int, cursor *string) (turso.ListResponse, error) {
 	cursorStr := ""
 	if cursor != nil {
 		cursorStr = *cursor
@@ -47,7 +104,9 @@ var listCmd = &cobra.Command{
 		}
 
 		fetcher := &DatabaseFetcher{
-			client: client,
+			client:       client,
+			SchemaFilter: schemaFilter,
+			GroupFilter:  groupFilter,
 		}
 		return printDatabaseList(fetcher)
 	},

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
-	"github.com/tursodatabase/turso-cli/internal/turso"
 )
 
 func init() {
@@ -21,38 +20,6 @@ func init() {
 	showCmd.Flags().BoolVar(&showBranchesFlag, "branches", false, "Show a list of branches for this database.")
 	showCmd.RegisterFlagCompletionFunc("instance-url", completeInstanceName)
 	showCmd.RegisterFlagCompletionFunc("instance-ws-url", completeInstanceName)
-}
-
-type BranchFetcher struct {
-	client *turso.Client
-	parent string
-}
-
-func (bf *BranchFetcher) FetchPage(pageSize int, cursor *string) (turso.ListResponse, error) {
-	cursorStr := ""
-	if cursor != nil {
-		cursorStr = *cursor
-	}
-
-	options := turso.DatabaseListOptions{
-		Limit:  pageSize,
-		Cursor: cursorStr,
-		Parent: bf.parent,
-	}
-
-	r, err := bf.client.Databases.List(options)
-	if err != nil {
-		return turso.ListResponse{}, err
-	}
-
-	for i, database := range r.Databases {
-		db, err := getDatabase(bf.client, database.Name, false)
-		if err != nil {
-			return turso.ListResponse{}, err
-		}
-		r.Databases[i] = db
-	}
-	return r, nil
 }
 
 var showCmd = &cobra.Command{
@@ -87,9 +54,9 @@ var showCmd = &cobra.Command{
 		}
 
 		if showBranchesFlag {
-			fetcher := &BranchFetcher{
-				client: client,
-				parent: db.ID,
+			fetcher := &DatabaseFetcher{
+				client:     client,
+				ParentDbId: db.ID,
 			}
 			return printDatabaseList(fetcher)
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -38,7 +38,7 @@ var showCmd = &cobra.Command{
 			return err
 		}
 
-		config, err := client.Databases.GetConfig(db.Name)
+		config, err := getDatabaseConfig(client, db.Name)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -55,8 +55,9 @@ var showCmd = &cobra.Command{
 
 		if showBranchesFlag {
 			fetcher := &DatabaseFetcher{
-				client:     client,
-				ParentDbId: db.ID,
+				client:       client,
+				ParentDbId:   db.ID,
+				LoadFullInfo: true,
 			}
 			return printDatabaseList(fetcher)
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -123,11 +123,6 @@ var showCmd = &cobra.Command{
 
 		fmt.Println()
 
-		if len(instances) == 0 {
-			fmt.Printf("🛠 Run %s to finish your database creation!\n", internal.Emph("turso db replicate "+db.Name))
-			return nil
-		}
-
 		fmt.Print("Database Instances:\n")
 		printTable(headers, data)
 

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -293,7 +293,7 @@ func getGroup(client *turso.Client, name string) (turso.Group, error) {
 	if err != nil {
 		return turso.Group{}, err
 	}
-	if groupID != "" {
+	if groupID == "" {
 		return getGroupV2(client, name)
 	}
 	return client.GroupsV3.Get(orgID, groupID)

--- a/internal/cmd/group.go
+++ b/internal/cmd/group.go
@@ -227,22 +227,14 @@ func aggregateGroupStatus(group turso.Group) string {
 	if group.Archived {
 		return "Archived 💤"
 	}
-	allIdle := true
 	for _, locationStatus := range group.Status.Locations {
 		if group.Primary == locationStatus.Name && locationStatus.Status == "down" {
 			status = "Unhealthy"
 			break
 		}
-		if locationStatus.Status != "stopped" {
-			allIdle = false
-		}
 		if locationStatus.Status == "down" {
-			allIdle = false
 			status = "Degraded"
 		}
-	}
-	if allIdle {
-		status = "Idle"
 	}
 	return status
 }
@@ -252,12 +244,26 @@ func getGroups(client *turso.Client, fresh ...bool) ([]turso.Group, error) {
 	if cached := getGroupsCache(client.Org); !skipCache && cached != nil {
 		return cached, nil
 	}
-	groups, err := client.Groups.List()
+	groups, err := listGroups(client)
 	if err != nil {
 		return nil, err
 	}
 	setGroupsCache(client.Org, groups)
 	return groups, nil
+}
+
+func listGroups(client *turso.Client) ([]turso.Group, error) {
+	if !flags.V3Api() {
+		return client.Groups.List()
+	}
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return nil, err
+	}
+	if orgID == "" {
+		return client.Groups.List()
+	}
+	return client.GroupsV3.List(orgID)
 }
 
 func groupNames(client *turso.Client) ([]string, error) {
@@ -273,6 +279,27 @@ func groupNames(client *turso.Client) ([]string, error) {
 }
 
 func getGroup(client *turso.Client, name string) (turso.Group, error) {
+	if !flags.V3Api() {
+		return getGroupV2(client, name)
+	}
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return turso.Group{}, err
+	}
+	if orgID == "" {
+		return getGroupV2(client, name)
+	}
+	groupID, err := tryResolveGroupID(client, name)
+	if err != nil {
+		return turso.Group{}, err
+	}
+	if groupID != "" {
+		return getGroupV2(client, name)
+	}
+	return client.GroupsV3.Get(orgID, groupID)
+}
+
+func getGroupV2(client *turso.Client, name string) (turso.Group, error) {
 	groups, err := getGroups(client)
 	if err != nil {
 		return turso.Group{}, err

--- a/internal/cmd/ids.go
+++ b/internal/cmd/ids.go
@@ -5,6 +5,8 @@ import (
 )
 
 func tryResolveOrgID(client *turso.Client) (string, error) {
+	groups := getGroupsCache(client.Org)
+
 	slug := client.Org
 	if orgs := getOrgsCache(); orgs != nil {
 		if id := findOrgID(orgs, slug); id != "" {
@@ -16,6 +18,7 @@ func tryResolveOrgID(client *turso.Client) (string, error) {
 		return "", err
 	}
 	setOrgsCache(orgs)
+	setGroupsCache(client.Org, groups)
 	return findOrgID(orgs, slug), nil
 }
 

--- a/internal/cmd/ids.go
+++ b/internal/cmd/ids.go
@@ -34,8 +34,8 @@ func findOrgID(orgs []turso.Organization, slug string) string {
 func tryResolveGroupID(client *turso.Client, name string) (string, error) {
 	if groups := getGroupsCache(client.Org); groups != nil {
 		for _, g := range groups {
-			if g.Name == name && g.ID != "" {
-				return g.ID, nil
+			if g.Name == name && g.UUID != "" {
+				return g.UUID, nil
 			}
 		}
 	}
@@ -44,7 +44,7 @@ func tryResolveGroupID(client *turso.Client, name string) (string, error) {
 		return "", err
 	}
 	mergeGroupIntoCache(client.Org, group)
-	return group.ID, nil
+	return group.UUID, nil
 }
 
 func mergeGroupIntoCache(org string, group turso.Group) {

--- a/internal/cmd/ids.go
+++ b/internal/cmd/ids.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"github.com/tursodatabase/turso-cli/internal/turso"
+)
+
+func tryResolveOrgID(client *turso.Client) (string, error) {
+	slug := client.Org
+	if orgs := getOrgsCache(); orgs != nil {
+		if id := findOrgID(orgs, slug); id != "" {
+			return id, nil
+		}
+	}
+	orgs, err := client.Organizations.List()
+	if err != nil {
+		return "", err
+	}
+	setOrgsCache(orgs)
+	return findOrgID(orgs, slug), nil
+}
+
+func findOrgID(orgs []turso.Organization, slug string) string {
+	for _, o := range orgs {
+		if o.Slug == slug {
+			return o.ID
+		}
+	}
+	return ""
+}
+
+func tryResolveGroupID(client *turso.Client, name string) (string, error) {
+	if groups := getGroupsCache(client.Org); groups != nil {
+		for _, g := range groups {
+			if g.Name == name && g.ID != "" {
+				return g.ID, nil
+			}
+		}
+	}
+	group, err := client.Groups.Get(name)
+	if err != nil {
+		return "", err
+	}
+	mergeGroupIntoCache(client.Org, group)
+	return group.ID, nil
+}
+
+func mergeGroupIntoCache(org string, group turso.Group) {
+	groups := getGroupsCache(org)
+	replaced := false
+	for i := range groups {
+		if groups[i].Name == group.Name {
+			groups[i] = group
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		groups = append(groups, group)
+	}
+	setGroupsCache(org, groups)
+}
+
+func tryResolveDbID(client *turso.Client, name string) (string, error) {
+	if dbs := getDatabasesCache(); dbs != nil {
+		for _, db := range dbs {
+			if db.Name == name && db.ID != "" {
+				return db.ID, nil
+			}
+		}
+	}
+	db, err := client.Databases.Get(name)
+	if err != nil {
+		return "", err
+	}
+	mergeDatabaseIntoCache(db)
+	return db.ID, nil
+}
+
+func mergeDatabaseIntoCache(db turso.Database) {
+	dbs := getDatabasesCache()
+	replaced := false
+	for i := range dbs {
+		if dbs[i].Name == db.Name {
+			dbs[i] = db
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		dbs = append(dbs, db)
+	}
+	setDatabasesCache(dbs)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -112,6 +112,7 @@ func init() {
 	}
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	flags.AddDebugFlag(rootCmd)
+	flags.AddV3ApiFlag(rootCmd)
 	flags.AddResetConfigFlag(rootCmd)
 }
 

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/tursodatabase/turso-cli/internal"
+	"github.com/tursodatabase/turso-cli/internal/flags"
 	"github.com/tursodatabase/turso-cli/internal/prompt"
 	"github.com/tursodatabase/turso-cli/internal/settings"
 	"github.com/tursodatabase/turso-cli/internal/turso"
@@ -376,6 +377,9 @@ func fetchLatestVersion() (string, error) {
 }
 
 func instancesAndUsage(client *turso.Client, database string) (instances []turso.Instance, usage turso.DbUsage, err error) {
+	if flags.V3Api() {
+		return nil, turso.DbUsage{}, nil
+	}
 	g := errgroup.Group{}
 	g.Go(func() (err error) {
 		instances, err = client.Instances.List(database)

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -188,20 +188,24 @@ func destroyDatabases(client *turso.Client, names []string) error {
 }
 
 func deleteDatabase(client *turso.Client, name string) error {
+	if !flags.V3Api() {
+		return client.Databases.Delete(name)
+	}
 	orgID, err := tryResolveOrgID(client)
 	if err != nil {
 		return err
 	}
-	if orgID != "" {
-		dbID, err := tryResolveDbID(client, name)
-		if err != nil {
-			return err
-		}
-		if dbID != "" {
-			return client.DatabasesV3.Delete(orgID, dbID)
-		}
+	if orgID == "" {
+		return client.Databases.Delete(name)
 	}
-	return client.Databases.Delete(name)
+	dbID, err := tryResolveDbID(client, name)
+	if err != nil {
+		return err
+	}
+	if dbID == "" {
+		return client.Databases.Delete(name)
+	}
+	return client.DatabasesV3.Delete(orgID, dbID)
 }
 
 func destroyDatabaseRegion(client *turso.Client, database, region string) error {

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -164,7 +164,7 @@ func destroyDatabases(client *turso.Client, names []string) error {
 	for _, name := range names {
 		name := name
 		g.Go(func() error {
-			return client.Databases.Delete(name)
+			return deleteDatabase(client, name)
 		})
 	}
 
@@ -184,6 +184,23 @@ func destroyDatabases(client *turso.Client, names []string) error {
 	fmt.Println(msg)
 
 	return nil
+}
+
+func deleteDatabase(client *turso.Client, name string) error {
+	orgID, err := tryResolveOrgID(client)
+	if err != nil {
+		return err
+	}
+	if orgID != "" {
+		dbID, err := tryResolveDbID(client, name)
+		if err != nil {
+			return err
+		}
+		if dbID != "" {
+			return client.DatabasesV3.Delete(orgID, dbID)
+		}
+	}
+	return client.Databases.Delete(name)
 }
 
 func destroyDatabaseRegion(client *turso.Client, database, region string) error {

--- a/internal/flags/v3api.go
+++ b/internal/flags/v3api.go
@@ -1,0 +1,17 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var v3ApiFlag bool
+
+func AddV3ApiFlag(cmd *cobra.Command) {
+	usage := "If set, use V3 api when possible."
+	cmd.PersistentFlags().BoolVar(&v3ApiFlag, "v3-api", false, usage)
+	cmd.PersistentFlags().MarkHidden("v3-api")
+}
+
+func V3Api() bool {
+	return v3ApiFlag
+}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -95,6 +95,36 @@ func (d *DatabasesClient) List(options DatabaseListOptions) (ListResponse, error
 	return resp, nil
 }
 
+func (d *DatabasesClient) Get(name string) (Database, error) {
+	r, err := d.client.Get(d.URL("/"+name), nil)
+	if err != nil {
+		return Database{}, fmt.Errorf("failed to get database %s: %w", name, err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return Database{}, notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		return Database{}, fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(name), internal.Emph("turso db list"))
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return Database{}, fmt.Errorf("failed to get database %s: %w", name, parseResponseError(r))
+	}
+
+	type Response struct {
+		Database Database `json:"database"`
+	}
+	resp, err := unmarshal[Response](r)
+	if err != nil {
+		return Database{}, err
+	}
+	return resp.Database, nil
+}
+
 func (d *DatabasesClient) Delete(database string) error {
 	url := d.URL("/" + database)
 	r, err := d.client.Delete(url, nil)

--- a/internal/turso/databases_v3.go
+++ b/internal/turso/databases_v3.go
@@ -33,7 +33,7 @@ type DatabaseV3ListOptions struct {
 	Cursor     string
 }
 
-func (d *DatabasesV3Client) List(orgID string, options DatabaseV3ListOptions) ([]Database, error) {
+func (d *DatabasesV3Client) List(orgID string, options DatabaseV3ListOptions) ([]Database, string, error) {
 	path := d.url(orgID, "")
 	q := url.Values{}
 	if options.GroupId != "" {
@@ -54,22 +54,23 @@ func (d *DatabasesV3Client) List(orgID string, options DatabaseV3ListOptions) ([
 
 	r, err := d.client.Get(path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list databases: %w", err)
+		return nil, "", fmt.Errorf("failed to list databases: %w", err)
 	}
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list databases: %w", parseResponseError(r))
+		return nil, "", fmt.Errorf("failed to list databases: %w", parseResponseError(r))
 	}
 
 	type response struct {
-		Databases []Database `json:"databases"`
+		Databases  []Database `json:"databases"`
+		NextCursor string     `json:"next_cursor"`
 	}
 	resp, err := unmarshal[response](r)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return resp.Databases, nil
+	return resp.Databases, resp.NextCursor, nil
 }
 
 func (d *DatabasesV3Client) Get(orgID, dbID string) (Database, error) {
@@ -89,6 +90,27 @@ func (d *DatabasesV3Client) Get(orgID, dbID string) (Database, error) {
 	resp, err := unmarshal[response](r)
 	if err != nil {
 		return Database{}, err
+	}
+	return resp.Database, nil
+}
+
+func (d *DatabasesV3Client) GetConfig(orgID, dbID string) (DatabaseConfig, error) {
+	r, err := d.client.Get(d.url(orgID, "/"+dbID), nil)
+	if err != nil {
+		return DatabaseConfig{}, fmt.Errorf("failed to get database: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return DatabaseConfig{}, fmt.Errorf("failed to get database: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Database DatabaseConfig `json:"database"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return DatabaseConfig{}, err
 	}
 	return resp.Database, nil
 }

--- a/internal/turso/databases_v3.go
+++ b/internal/turso/databases_v3.go
@@ -1,0 +1,176 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/tursodatabase/turso-cli/internal/flags"
+)
+
+type DatabasesV3Client client
+
+type CreateDatabaseV3Body struct {
+	Name             string            `json:"name"`
+	GroupID          string            `json:"group_id,omitempty"`
+	DatabaseType     string            `json:"database_type,omitempty"`
+	CreationMode     string            `json:"creation_mode,omitempty"`
+	ParentDBName     string            `json:"parent_db_name,omitempty"`
+	Timestamp        *time.Time        `json:"parent_db_timestamp,omitempty"`
+	RemoteEncryption *RemoteEncryption `json:"remote_encryption,omitempty"`
+}
+
+func (d *DatabasesV3Client) url(orgID, suffix string) string {
+	return "/v3/organizations/" + orgID + "/databases" + suffix
+}
+
+type DatabaseV3ListOptions struct {
+	GroupId    string
+	ParentDbId string
+	Limit      int
+	Cursor     string
+}
+
+func (d *DatabasesV3Client) List(orgID string, options DatabaseV3ListOptions) ([]Database, error) {
+	path := d.url(orgID, "")
+	q := url.Values{}
+	if options.GroupId != "" {
+		q.Set("group_id", options.GroupId)
+	}
+	if options.ParentDbId != "" {
+		q.Set("parent_db_id", options.ParentDbId)
+	}
+	if options.Limit != 0 {
+		q.Set("limit", strconv.Itoa(options.Limit))
+	}
+	if options.Cursor != "" {
+		q.Set("cursor", options.Cursor)
+	}
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+
+	r, err := d.client.Get(path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list databases: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list databases: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Databases []Database `json:"databases"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Databases, nil
+}
+
+func (d *DatabasesV3Client) Get(orgID, dbID string) (Database, error) {
+	r, err := d.client.Get(d.url(orgID, "/"+dbID), nil)
+	if err != nil {
+		return Database{}, fmt.Errorf("failed to get database: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return Database{}, fmt.Errorf("failed to get database: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Database Database `json:"database"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return Database{}, err
+	}
+	return resp.Database, nil
+}
+
+func (d *DatabasesV3Client) Delete(orgID, dbID string) error {
+	r, err := d.client.Delete(d.url(orgID, "/"+dbID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete database: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete database: %w", parseResponseError(r))
+	}
+	return nil
+}
+
+func (d *DatabasesV3Client) Create(orgID string, body CreateDatabaseV3Body) (Database, error) {
+	payload, err := marshal(body)
+	if err != nil {
+		return Database{}, fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	r, err := d.client.Post(d.url(orgID, ""), payload)
+	if err != nil {
+		return Database{}, fmt.Errorf("failed to create database: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return Database{}, fmt.Errorf("failed to create database: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Database Database `json:"database"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return Database{}, err
+	}
+	return resp.Database, nil
+}
+
+func (d *DatabasesV3Client) Token(
+	orgID string, dbID string,
+	expiration string,
+	readOnly bool,
+	fineGrainedPermissions []flags.FineGrainedPermissions,
+) (string, error) {
+	q := url.Values{}
+	if expiration != "" {
+		q.Set("expiration", expiration)
+	}
+	if readOnly {
+		q.Set("authorization", "read-only")
+	}
+	path := d.url(orgID, "/"+dbID+"/auth/tokens")
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+
+	req := DatabaseTokenRequest{FineGrainedPermissions: fineGrainedPermissions}
+	body, err := marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize request body: %w", err)
+	}
+	r, err := d.client.Post(path, body)
+	if err != nil {
+		return "", fmt.Errorf("failed to get database token: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get database token: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Jwt string `json:"jwt"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return "", err
+	}
+	return resp.Jwt, nil
+}

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -19,6 +19,7 @@ type GroupStatus struct {
 	Locations []LocationStatus `json:"locations"`
 }
 type Group struct {
+	ID        string      `json:"id,omitempty"`
 	Name      string      `json:"name"`
 	Locations []string    `json:"locations"`
 	Primary   string      `json:"primary"`

--- a/internal/turso/groups.go
+++ b/internal/turso/groups.go
@@ -19,7 +19,7 @@ type GroupStatus struct {
 	Locations []LocationStatus `json:"locations"`
 }
 type Group struct {
-	ID        string      `json:"id,omitempty"`
+	UUID      string      `json:"uuid,omitempty"`
 	Name      string      `json:"name"`
 	Locations []string    `json:"locations"`
 	Primary   string      `json:"primary"`

--- a/internal/turso/groups_v3.go
+++ b/internal/turso/groups_v3.go
@@ -1,0 +1,54 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type GroupsV3Client client
+
+func (g *GroupsV3Client) url(orgID, suffix string) string {
+	return "/v3/organizations/" + orgID + "/groups" + suffix
+}
+
+func (g *GroupsV3Client) List(orgID string) ([]Group, error) {
+	r, err := g.client.Get(g.url(orgID, ""), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list groups: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Groups []Group `json:"groups"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Groups, nil
+}
+
+func (g *GroupsV3Client) Get(orgID, groupID string) (Group, error) {
+	r, err := g.client.Get(g.url(orgID, "/"+groupID), nil)
+	if err != nil {
+		return Group{}, fmt.Errorf("failed to get group: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return Group{}, fmt.Errorf("failed to get group: %w", parseResponseError(r))
+	}
+
+	type response struct {
+		Group Group `json:"group"`
+	}
+	resp, err := unmarshal[response](r)
+	if err != nil {
+		return Group{}, err
+	}
+	return resp.Group, nil
+}

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -16,6 +16,7 @@ import (
 type OrganizationsClient client
 
 type Organization struct {
+	ID       string `json:"id,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Slug     string `json:"slug,omitempty"`
 	Type     string `json:"type,omitempty"`

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -27,6 +27,7 @@ type Client struct {
 
 	Instances     *InstancesClient
 	Databases     *DatabasesClient
+	DatabasesV3   *DatabasesV3Client
 	Organizations *OrganizationsClient
 	ApiTokens     *ApiTokensClient
 	Locations     *LocationsClient
@@ -50,6 +51,7 @@ func New(base *url.URL, token string, cliVersion string, org string) *Client {
 	c.base = &client{c}
 	c.Instances = (*InstancesClient)(c.base)
 	c.Databases = (*DatabasesClient)(c.base)
+	c.DatabasesV3 = (*DatabasesV3Client)(c.base)
 	c.Organizations = (*OrganizationsClient)(c.base)
 	c.ApiTokens = (*ApiTokensClient)(c.base)
 	c.Locations = (*LocationsClient)(c.base)

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -37,6 +37,7 @@ type Client struct {
 	Subscriptions *SubscriptionClient
 	Billing       *BillingClient
 	Groups        *GroupsClient
+	GroupsV3      *GroupsV3Client
 	Invoices      *InvoicesClient
 }
 
@@ -61,6 +62,7 @@ func New(base *url.URL, token string, cliVersion string, org string) *Client {
 	c.Subscriptions = (*SubscriptionClient)(c.base)
 	c.Billing = (*BillingClient)(c.base)
 	c.Groups = (*GroupsClient)(c.base)
+	c.GroupsV3 = (*GroupsV3Client)(c.base)
 	c.Invoices = (*InvoicesClient)(c.base)
 	return c
 }

--- a/internal/turso/utils.go
+++ b/internal/turso/utils.go
@@ -48,7 +48,7 @@ func GetFeatureError(body []byte, feature string) error {
 func parseResponseError(res *http.Response) error {
 	d, err := io.ReadAll(res.Body)
 	if err != nil {
-		return fmt.Errorf("response failed with status %s", res.Status)
+		return fmt.Errorf("response failed with status %s (%s)", res.Status, d)
 	}
 
 	var errResp ErrorResponseDetails
@@ -57,5 +57,5 @@ func parseResponseError(res *http.Response) error {
 			return fmt.Errorf("%v", errResp.Error)
 		}
 	}
-	return fmt.Errorf("response failed with status %s", res.Status)
+	return fmt.Errorf("response failed with status %s (%s)", res.Status, d)
 }


### PR DESCRIPTION
Use regional db-api endpoints if `--v3-api` flag is set for db-related operations (create/show/list/etc)