### PR TITLE
Show database type in db commands

### DIFF
--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/google/uuid"
 
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
@@ -113,6 +114,7 @@ var showCmd = &cobra.Command{
 		fmt.Println("Archived:          ", formatBool(db.Sleeping))
 		fmt.Println("Bytes Synced:      ", humanize.Bytes(dbUsage.Usage.BytesSynced))
 		fmt.Println("Is Schema:         ", formatBool(db.IsSchema))
+		fmt.Println("Type:              ", databaseType(dbUsage.UUID))
 		fmt.Println("Delete Protection: ", formatBool(config.IsDeleteProtected()))
 		if db.Schema != "" {
 			fmt.Println("Schema:            ", db.Schema)
@@ -128,4 +130,19 @@ var showCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func isTursoDB(dbUUID string) bool {
+	id, err := uuid.Parse(dbUUID)
+	if err != nil {
+		return false
+	}
+	return id[5] == 0x10
+}
+
+func databaseType(dbUUID string) string {
+	if isTursoDB(dbUUID) {
+		return "Turso"
+	}
+	return "SQLite"
 }

--- a/internal/cmd/db_show_test.go
+++ b/internal/cmd/db_show_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import "testing"
+
+func TestIsTursoDB(t *testing.T) {
+	tests := []struct {
+		name  string
+		uuid  string
+		turso bool
+	}{
+		{
+			name:  "type byte is 0x10",
+			uuid:  "019db7a2-9210-79e5-afed-0b1755901d50",
+			turso: true,
+		},
+		{
+			name:  "type byte is not 0x10",
+			uuid:  "00000000-1100-0000-0000-000000000000",
+			turso: false,
+		},
+		{
+			name:  "invalid uuid",
+			uuid:  "not-a-uuid",
+			turso: false,
+		},
+		{
+			name:  "empty uuid",
+			uuid:  "",
+			turso: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTursoDB(tt.uuid)
+			if got != tt.turso {
+				t.Fatalf("isTursoDB(%q) = %v, want %v", tt.uuid, got, tt.turso)
+			}
+		})
+	}
+}
+
+func TestDatabaseType(t *testing.T) {
+	tests := []struct {
+		uuid string
+		want string
+	}{
+		{
+			uuid: "019db7a2-9210-79e5-afed-0b1755901d50",
+			want: "Turso",
+		},
+		{
+			uuid: "00000000-1100-0000-0000-000000000000",
+			want: "SQLite",
+		},
+		{
+			uuid: "",
+			want: "SQLite",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := databaseType(tt.uuid)
+			if got != tt.want {
+				t.Fatalf("databaseType(%q) = %q, want %q", tt.uuid, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/list_databases.go
+++ b/internal/cmd/list_databases.go
@@ -116,12 +116,14 @@ func (m dbListModel) View() string {
 
 	for _, database := range m.databases {
 		row := []string{database.Name}
+		row = append(row, databaseType(database.ID))
 		row = append(row, formatGroup(database.Group))
 		row = append(row, getDatabaseUrl(&database))
 		data = append(data, row)
 	}
 
 	headers = append(headers, "NAME")
+	headers = append(headers, "TYPE")
 	headers = append(headers, "GROUP")
 	headers = append(headers, "URL")
 

--- a/internal/cmd/list_databases_test.go
+++ b/internal/cmd/list_databases_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tursodatabase/turso-cli/internal/turso"
+)
+
+func TestDbListModelViewIncludesTypeColumn(t *testing.T) {
+	model := dbListModel{
+		databases: []turso.Database{
+			{
+				Name:     "sqlite-db",
+				ID:       "00000000-1100-0000-0000-000000000000",
+				Hostname: "sqlite-db.example.com",
+			},
+			{
+				Name:     "turso-db",
+				ID:       "019db7a2-9210-79e5-afed-0b1755901d50",
+				Group:    "default",
+				Hostname: "turso-db.example.com",
+			},
+		},
+	}
+
+	view := model.View()
+	lines := strings.Split(strings.TrimSpace(view), "\n")
+	expected := [][]string{
+		{"NAME", "TYPE", "GROUP", "URL"},
+		{"sqlite-db", "SQLite", "-", "libsql://sqlite-db.example.com"},
+		{"turso-db", "Turso", "default", "libsql://turso-db.example.com"},
+	}
+
+	if len(lines) != len(expected) {
+		t.Fatalf("expected %d lines, got %d:\n%s", len(expected), len(lines), view)
+	}
+
+	for i, want := range expected {
+		got := strings.Fields(lines[i])
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Fatalf("line %d fields = %q, want %q:\n%s", i, got, want, view)
+		}
+	}
+}


### PR DESCRIPTION
Adds `Type` field to `db show` and `db list` commands to distinguish between `tursodb` and `sqlite`

### DB Show
<img width="977" height="298" alt="image" src="https://github.com/user-attachments/assets/1488aa04-4e3d-41f5-8e20-583d1333c11d" />



### DB List
<img width="977" height="265" alt="image" src="https://github.com/user-attachments/assets/a56b0817-e6c3-420f-be78-2de25b346c3a" />
