### PR TITLE
fix db import command to match new sqlite3 output in line mode

### DIFF
--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -297,17 +297,16 @@ func sqliteFileIntegrityChecks(file string, cipher string) error {
 	}
 
 	settings := string(output)
-	if !strings.Contains(settings, "j = wal") {
+	if !strings.Contains(settings, "j: wal") && !strings.Contains(settings, "j = wal") {
 		return fmt.Errorf("database is not in WAL mode. Set it with 'sqlite3 %s 'PRAGMA journal_mode = WAL'", file)
 	}
-
-	if !strings.Contains(settings, "p = 4096") {
+	if !strings.Contains(settings, "p: 4096") && !strings.Contains(settings, "p = 4096") {
 		return fmt.Errorf("database must use 4KB page size. you can set it with 'sqlite3 %s 'PRAGMA page_size = 4096; VACUUM;' Note that this is not possible to do if your database is already in WAL mode", file)
 	}
-	if !strings.Contains(settings, "a = 0") {
+	if !strings.Contains(settings, "a: 0") && !strings.Contains(settings, "a = 0") {
 		return fmt.Errorf("database must have autovacuum disabled. you can set it with 'sqlite3 %s 'PRAGMA auto_vacuum = 0;'", file)
 	}
-	if !strings.Contains(settings, "e = UTF-8") {
+	if !strings.Contains(settings, "e: UTF-8") && !strings.Contains(settings, "e = UTF-8") {
 		return fmt.Errorf("database must use UTF-8 encoding. you can set it with 'sqlite3 %s 'PRAGMA encoding = 'UTF-8'	", file)
 	}
 


### PR DESCRIPTION
this was breaking `turso db import` because the new `.mode line` uses `key: value` instead of `key = value`