### PR TITLE
fix(db import): query each PRAGMA individually so checks survive sqlite3 format changes

### DIFF
--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -289,24 +289,36 @@ func sqliteFileIntegrityChecks(file string, cipher string) error {
 	if flags.Debug() {
 		log.Printf("Checking database settings...")
 	}
-	output, err := exec.Command("sqlite3", "-list", file, ".mode line",
-		"select journal_mode as j, page_size as p, auto_vacuum as a, encoding as e from pragma_journal_mode, pragma_page_size, pragma_auto_vacuum, pragma_encoding;").CombinedOutput()
-	if err != nil {
 
+	journalMode, err := readPragma(file, "journal_mode")
+	if err != nil {
 		return fmt.Errorf("failed to check database settings: %w", err)
 	}
-
-	settings := string(output)
-	if !strings.Contains(settings, "j: wal") && !strings.Contains(settings, "j = wal") {
+	if !strings.EqualFold(journalMode, "wal") {
 		return fmt.Errorf("database is not in WAL mode. Set it with 'sqlite3 %s 'PRAGMA journal_mode = WAL'", file)
 	}
-	if !strings.Contains(settings, "p: 4096") && !strings.Contains(settings, "p = 4096") {
+
+	pageSize, err := readPragma(file, "page_size")
+	if err != nil {
+		return fmt.Errorf("failed to check database settings: %w", err)
+	}
+	if pageSize != "4096" {
 		return fmt.Errorf("database must use 4KB page size. you can set it with 'sqlite3 %s 'PRAGMA page_size = 4096; VACUUM;' Note that this is not possible to do if your database is already in WAL mode", file)
 	}
-	if !strings.Contains(settings, "a: 0") && !strings.Contains(settings, "a = 0") {
+
+	autoVacuum, err := readPragma(file, "auto_vacuum")
+	if err != nil {
+		return fmt.Errorf("failed to check database settings: %w", err)
+	}
+	if autoVacuum != "0" {
 		return fmt.Errorf("database must have autovacuum disabled. you can set it with 'sqlite3 %s 'PRAGMA auto_vacuum = 0;'", file)
 	}
-	if !strings.Contains(settings, "e: UTF-8") && !strings.Contains(settings, "e = UTF-8") {
+
+	encoding, err := readPragma(file, "encoding")
+	if err != nil {
+		return fmt.Errorf("failed to check database settings: %w", err)
+	}
+	if encoding != "UTF-8" {
 		return fmt.Errorf("database must use UTF-8 encoding. you can set it with 'sqlite3 %s 'PRAGMA encoding = 'UTF-8'	", file)
 	}
 
@@ -338,6 +350,19 @@ func runQuickCheck(file string) error {
 		return fmt.Errorf("integrity check failed: %w", err)
 	}
 	return nil
+}
+
+// readPragma runs a single PRAGMA query against the SQLite file via the system
+// sqlite3 binary and returns the trimmed value. One query per pragma keeps the
+// result independent of sqlite3's output-mode formatting, which changed between
+// 3.49 and 3.50 (".mode line" went from "key = value" to "key: value"). See #1030.
+func readPragma(file, pragma string) (string, error) {
+	out, err := exec.Command("sqlite3", "-batch", "-noheader", "-list", file,
+		fmt.Sprintf("select * from pragma_%s;", pragma)).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to read pragma_%s: %w", pragma, err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func handleDBFileAWS(file string, cipher string) (*turso.DBSeed, error) {

--- a/internal/cmd/group_flag_test.go
+++ b/internal/cmd/group_flag_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,83 @@ func createTestDatabase(t *testing.T, sizeBytes int) string {
 	}
 
 	return dbPath
+}
+
+func TestReadPragma(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not available, skipping test")
+	}
+
+	dbPath := createTestDatabase(t, 4096)
+
+	t.Run("journal_mode returns wal", func(t *testing.T) {
+		v, err := readPragma(dbPath, "journal_mode")
+		require.NoError(t, err)
+		require.True(t, strings.EqualFold(v, "wal"), "got %q", v)
+	})
+
+	t.Run("page_size returns 4096", func(t *testing.T) {
+		v, err := readPragma(dbPath, "page_size")
+		require.NoError(t, err)
+		require.Equal(t, "4096", v)
+	})
+
+	t.Run("auto_vacuum returns 0", func(t *testing.T) {
+		v, err := readPragma(dbPath, "auto_vacuum")
+		require.NoError(t, err)
+		require.Equal(t, "0", v)
+	})
+
+	t.Run("encoding returns UTF-8", func(t *testing.T) {
+		v, err := readPragma(dbPath, "encoding")
+		require.NoError(t, err)
+		require.Equal(t, "UTF-8", v)
+	})
+
+	t.Run("nonexistent file errors", func(t *testing.T) {
+		_, err := readPragma("/nonexistent/path/db.sqlite", "journal_mode")
+		require.Error(t, err)
+	})
+}
+
+func TestSqliteFileIntegrityChecks(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not available, skipping test")
+	}
+
+	t.Run("valid WAL database passes all settings checks", func(t *testing.T) {
+		dbPath := createTestDatabase(t, 4096)
+		err := sqliteFileIntegrityChecks(dbPath, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("non-WAL database returns WAL error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "delete.db")
+		cmd := exec.Command("sqlite3", "-list", dbPath,
+			"PRAGMA page_size=4096;",
+			"PRAGMA journal_mode=DELETE;",
+			"CREATE TABLE t (id INTEGER PRIMARY KEY);")
+		require.NoError(t, cmd.Run())
+
+		err := sqliteFileIntegrityChecks(dbPath, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not in WAL mode")
+	})
+
+	t.Run("wrong page size returns page-size error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "8k.db")
+		cmd := exec.Command("sqlite3", "-list", dbPath,
+			"PRAGMA page_size=8192;",
+			"PRAGMA journal_mode=WAL;",
+			"CREATE TABLE t (id INTEGER PRIMARY KEY);")
+		require.NoError(t, cmd.Run())
+
+		err := sqliteFileIntegrityChecks(dbPath, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "4KB page size")
+	})
 }
 
 func TestRunQuickCheck(t *testing.T) {


### PR DESCRIPTION
Fixes #1030.

## Problem

`turso db import` runs `sqliteFileIntegrityChecks`, which executes one `.mode line` query and string-matches the resulting text for `j = wal` / `j: wal` etc. The dual-separator check covers today's `=` vs `:` split, but it depends entirely on whatever line formatter sqlite3 happens to emit. When sqlite3 changes that format again, the check breaks again — and it _has_ already broken once, between 3.49 and 3.50.

## Fix

Query each pragma with its own short statement:

```go
sqlite3 -batch -noheader -list <file> "select * from pragma_journal_mode;"
```

That returns just `wal` — no key, no separator, no column header — regardless of how `.mode line` is formatted in any future sqlite3 version. Compare the trimmed value against the expected literal.

Added a `readPragma(file, pragma)` helper next to `runQuickCheck` and refactored `sqliteFileIntegrityChecks` to call it four times. Same error messages, same exit conditions, format-independent.

## Tests

```
$ go test -v ./internal/cmd/...
=== RUN   TestReadPragma
--- PASS: TestReadPragma (0.09s)
    --- PASS: TestReadPragma/journal_mode_returns_wal
    --- PASS: TestReadPragma/page_size_returns_4096
    --- PASS: TestReadPragma/auto_vacuum_returns_0
    --- PASS: TestReadPragma/encoding_returns_UTF-8
    --- PASS: TestReadPragma/nonexistent_file_errors
=== RUN   TestSqliteFileIntegrityChecks
--- PASS: TestSqliteFileIntegrityChecks (0.10s)
    --- PASS: TestSqliteFileIntegrityChecks/valid_WAL_database_passes_all_settings_checks
    --- PASS: TestSqliteFileIntegrityChecks/non-WAL_database_returns_WAL_error
    --- PASS: TestSqliteFileIntegrityChecks/wrong_page_size_returns_page-size_error
=== RUN   TestRunQuickCheck
--- PASS: TestRunQuickCheck (0.12s)
    [all existing subtests pass]
PASS
ok      github.com/tursodatabase/turso-cli/internal/cmd 0.328s
```

Verified against system sqlite3 3.46.1 in golang:1.25 CI image. Existing `TestRunQuickCheck` continues to pass.

## Disclosure

This PR was prepared by an AI agent (Claude Opus 4.7) under direct human review. Happy to address any feedback.