### PR TITLE
fix(db export): explain unsupported Fly exports

### DIFF
--- a/internal/turso/tursoServer.go
+++ b/internal/turso/tursoServer.go
@@ -459,7 +459,7 @@ func (i *TursoServerClient) Export(outputFile string, withMetadata bool, remoteE
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return parseResponseError(res)
+		return parseExportResponseError(res)
 	}
 	var info ExportInfo
 	if err := json.NewDecoder(res.Body).Decode(&info); err != nil {
@@ -472,7 +472,7 @@ func (i *TursoServerClient) Export(outputFile string, withMetadata bool, remoteE
 	}
 	defer exportRes.Body.Close()
 	if exportRes.StatusCode != http.StatusOK {
-		return parseResponseError(exportRes)
+		return parseExportResponseError(exportRes)
 	}
 
 	out, err := os.Create(outputFile)
@@ -495,6 +495,13 @@ func (i *TursoServerClient) Export(outputFile string, withMetadata bool, remoteE
 	}
 
 	return nil
+}
+
+func parseExportResponseError(res *http.Response) error {
+	if res.StatusCode == http.StatusNotFound {
+		return errors.New("database export is not available for this database. If this is a Fly-hosted database, use `turso db shell <database> .dump` to create a SQL dump instead")
+	}
+	return parseResponseError(res)
 }
 
 func (i *TursoServerClient) ExportWAL(outputFile string, info *ExportInfo, remoteEncryptionKey string) (int, error) {

--- a/internal/turso/tursoServer_test.go
+++ b/internal/turso/tursoServer_test.go
@@ -907,6 +907,22 @@ func TestUploadFileMultipart_SmoothProgress(t *testing.T) {
 	require.True(t, calls[len(calls)-1].Done, "Final callback should have Done=true")
 }
 
+func TestExportReportsUnsupportedDatabaseForNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/info", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := createTestClient(t, server.URL)
+	err := client.Export("unused.db", false, "")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "database export is not available")
+	require.Contains(t, err.Error(), "Fly-hosted database")
+	require.NotContains(t, err.Error(), "response failed with status 404 Not Found")
+}
+
 // infiniteReader provides unlimited bytes for large file simulation (never returns EOF)
 type infiniteReader struct {
 	bytesRead int64


### PR DESCRIPTION
Fixes #981.

## Problem

When `turso db export` is run against a database whose export endpoints are unavailable, the CLI currently bubbles up a raw HTTP error like:

```
failed to export database: response failed with status 404 Not Found
```

For Fly-hosted databases, that does not explain what the user can do next.

## Fix

Handle 404 responses in the export path with a specific message explaining that database export is unavailable for that database and pointing users to `turso db shell <database> .dump` as the SQL dump fallback. Other export errors still use the existing response parser.

Added a regression test for the `/info` 404 path so the raw `response failed with status 404 Not Found` message does not come back.

## Tests

```
docker run --rm -v "$PWD":/src -w /src golang:1.25 gofmt -w internal/turso/tursoServer.go internal/turso/tursoServer_test.go
docker run --rm -v "$PWD":/src -w /src golang:1.25 go test ./internal/turso -run "TestExportReportsUnsupportedDatabaseForNotFound|TestUploadFileMultipart_ContentLengthHeader"
docker run --rm -v "$PWD":/src -w /src golang:1.25 go test ./internal/turso
```

## Disclosure

This PR was prepared by an AI agent under direct human review. Happy to adjust the wording if there is a preferred export fallback message.