### PR TITLE
fix(db): suggest database name for hostname prefix

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/tursodatabase/turso-cli/internal"
@@ -66,7 +67,20 @@ func getDatabase(client *turso.Client, name string, fresh ...bool) (turso.Databa
 		}
 	}
 
+	if suggestion := suggestDatabaseName(name, databases); suggestion != "" {
+		return turso.Database{}, fmt.Errorf("database %s not found. Did you mean %s? List known databases using %s", internal.Emph(name), internal.Emph(suggestion), internal.Emph("turso db list"))
+	}
 	return turso.Database{}, fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(name), internal.Emph("turso db list"))
+}
+
+func suggestDatabaseName(name string, databases []turso.Database) string {
+	for _, database := range databases {
+		hostPrefix, _, _ := strings.Cut(database.Hostname, ".")
+		if hostPrefix == name {
+			return database.Name
+		}
+	}
+	return ""
 }
 
 func listDatabases(client *turso.Client) ([]turso.Database, error) {

--- a/internal/cmd/db_test.go
+++ b/internal/cmd/db_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/tursodatabase/turso-cli/internal/turso"
+)
+
+func TestSuggestDatabaseNameFromHostnamePrefix(t *testing.T) {
+	databases := []turso.Database{
+		{
+			Name:     "hello",
+			Hostname: "hello-penberg.turso.io",
+		},
+		{
+			Name:     "other",
+			Hostname: "other-penberg.turso.io",
+		},
+	}
+
+	got := suggestDatabaseName("hello-penberg", databases)
+	if got != "hello" {
+		t.Fatalf("suggestDatabaseName() = %q, want %q", got, "hello")
+	}
+}
+
+func TestSuggestDatabaseNameIgnoresUnmatchedName(t *testing.T) {
+	databases := []turso.Database{
+		{
+			Name:     "hello",
+			Hostname: "hello-penberg.turso.io",
+		},
+	}
+
+	got := suggestDatabaseName("missing", databases)
+	if got != "" {
+		t.Fatalf("suggestDatabaseName() = %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
Fixes #606.

## Problem

A database named `hello` can have a hostname like `hello-penberg.turso.io`. Users may reasonably try:

```
turso db shell hello-penberg
```

and currently get only:

```
database hello-penberg not found. List known databases using turso db list
```

## Fix

When a database lookup by name fails, check whether the requested value matches the hostname prefix of a known database. If so, keep the command semantics unchanged but include a direct suggestion, e.g. `Did you mean hello?`.

I chose the suggestion path rather than an implicit alias so other commands do not silently operate on a different database name than the user typed.

## Tests

```
docker run --rm -v "$PWD":/src -w /src golang:1.25 gofmt -w internal/cmd/db.go internal/cmd/db_test.go
docker run --rm -v "$PWD":/src -w /src golang:1.25 go test ./internal/cmd -run "TestSuggestDatabaseName"
docker run --rm -v "$PWD":/src -w /src golang:1.25 go test ./internal/cmd
```

## Disclosure

This PR was prepared by an AI agent under direct human review. Happy to adjust the wording or alias behavior if maintainers prefer the other option from the issue.