### PR TITLE
db unarchive: suggest the group unarchive command when applicable

### DIFF
--- a/internal/cmd/db_wakeup.go
+++ b/internal/cmd/db_wakeup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -38,6 +39,16 @@ func wakeupDatabase(client *turso.Client, name string) error {
 	defer s.Stop()
 
 	if err := client.Databases.Wakeup(name); err != nil {
+		// If the database is part of a group the server tells us so
+		// but doesn't tell the user what to run instead. Look up the
+		// database to grab its group and suggest the right command.
+		// See #918.
+		if strings.Contains(err.Error(), "part of a group") {
+			if db, lookupErr := client.Databases.Get(name); lookupErr == nil && db.Group != "" {
+				cmd := internal.Emph(fmt.Sprintf("turso group unarchive %s", db.Group))
+				return fmt.Errorf("%w. Run %s instead", err, cmd)
+			}
+		}
 		return err
 	}
 	s.Stop()


### PR DESCRIPTION
Closes #918.

When a user runs \`turso db unarchive\` on a database that's part of a group, the server returns \"database X is part of a group, please unarchive the group instead\" but doesn't tell them how. Look up the database's group on that specific failure path and append the exact command (\`turso group unarchive <group>\`) to the error message, matching the pattern \`db_replicate\` already uses.

Falls back to the bare server error when the lookup fails.