### PR TITLE
from-csv: print sqlite's stderr as text instead of hex

### DIFF
--- a/internal/cmd/group_flag.go
+++ b/internal/cmd/group_flag.go
@@ -475,7 +475,11 @@ func importCSVIntoSQLite(tempDB *os.File, csvFile, csvTableName string, separato
 	cmd.Stderr = stdErr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("could not load csv into new database file: %w: %x", err, stdErr.Bytes())
+		// %x stringified sqlite3's stderr as hex bytes, so error
+		// messages came out as e.g. "4572726f723a206e6561...". Use
+		// %s and trim trailing whitespace so the actual sqlite
+		// message is visible. See #810.
+		return fmt.Errorf("could not load csv into new database file: %w: %s", err, strings.TrimSpace(stdErr.String()))
 	}
 	return nil
 }


### PR DESCRIPTION
Updates #810.

The error path stringified the captured stderr with \`%x\`, which turned sqlite3's actual message into a wall of hex digits. The reporter saw \`could not load csv into new database file: exit status 1: 4572726f723a206e656172...\` and had to hex-decode it manually to see what went wrong.

Switch to \`%s\` and trim trailing whitespace so the message reads as sqlite intended. Leaves the validation half of the issue (rejecting bad table names up front) for a separate change.