### PR TITLE
db create: derive group from source db when forking

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -99,7 +99,24 @@ func CreateDatabase(name string) error {
 
 	group, err := groupFromFlag(groups)
 	if err != nil {
-		return err
+		// Forking (--from-db) only works inside a single group, so
+		// if the user has multiple groups but didn't pick one we can
+		// derive the group from the source database. See #1004.
+		if fromDBFlag != "" && groupFlag == "" && len(groups) > 1 {
+			srcDB, getErr := client.Databases.Get(fromDBFlag)
+			if getErr == nil && srcDB.Group != "" {
+				for _, g := range groups {
+					if g.Name == srcDB.Group {
+						group = g
+						err = nil
+						break
+					}
+				}
+			}
+		}
+		if err != nil {
+			return err
+		}
 	}
 	groupName := group.Name
 


### PR DESCRIPTION
Closes #1004.

Forking with \`--from-db\` only works within a single group, so when the user has multiple groups but didn't specify \`--group\`, we can look up the source database and use its group instead of erroring out. Falls back to the original \"Please specify one with --group\" error if the lookup fails or the source database's group isn't in the user's group list.