### PR TITLE
Drop unused token arg from TokensClient.Validate

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -123,7 +123,7 @@ func isJwtTokenValid(token string) bool {
 	if err != nil {
 		return false
 	}
-	exp, err := client.Tokens.Validate(token)
+	exp, err := client.Tokens.Validate()
 	if err != nil {
 		return false
 	}

--- a/internal/turso/token.go
+++ b/internal/turso/token.go
@@ -7,7 +7,7 @@ import (
 
 type TokensClient client
 
-func (c *TokensClient) Validate(token string) (int64, error) {
+func (c *TokensClient) Validate() (int64, error) {
 	r, err := c.client.Get("/v1/auth/validate", nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to request validation: %s", err)


### PR DESCRIPTION
Closes #988.

@sanchitrk noted that `TokensClient.Validate(token)` ignored the `token` argument - the validation always runs against whatever token the underlying Client was constructed with. Dropping the unused arg so the signature stops lying. The single caller in `cmd/auth.go` is updated accordingly. `internal/` package so no external API impact.