### PR TITLE
Add native Windows CLI release builds and installer docs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -32,12 +32,6 @@ jobs:
       - name: Format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
 
-      - name: Build
-        run: go build -v ./...
-
-      - name: Vet
-        run: go vet -v ./...
-
       - name: Install sqlclosecheck
         # TODO revert to github.com/ryanrolds/sqlclosecheck when https://github.com/ryanrolds/sqlclosecheck/pull/47 is merged
         run: go install github.com/LeMikaelF/sqlclosecheck@b53ecaccb94623dfa6050e4ada4eeecd3a130829
@@ -52,8 +46,83 @@ jobs:
           build-tags: "preview"
           install-go: false
 
+  release-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
+      - name: Snapshot release (includes Windows)
+        run: goreleaser release --snapshot --clean --skip=publish --config .goreleaser-self.yaml
+
+      - name: Assert Windows archives exist
+        run: |
+          ls -la dist/
+          test -f dist/turso-cli_Windows_x86_64.zip
+          test -f dist/turso-cli_Windows_arm64.zip
+          unzip -l dist/turso-cli_Windows_x86_64.zip | grep -E 'turso\.exe$'
+
+  build:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Golang with cache
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Vet
+        run: go vet -v ./...
+
       - name: Test
         run: go test -v ./...
 
-      - name: Build Turso binary
-        run: go build -o turso cmd/turso/main.go
+      - name: Build Turso binary (dev)
+        shell: bash
+        run: |
+          EXT=""
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            EXT=".exe"
+          fi
+          go build -o "turso${EXT}" ./cmd/turso
+          "./turso${EXT}" --help >/dev/null
+          "./turso${EXT}" auth --help >/dev/null
+
+      - name: Prod generate and build
+        shell: bash
+        run: |
+          go generate --tags=prod ./...
+          EXT=""
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            EXT=".exe"
+          fi
+          go build -tags prod -o "turso-prod${EXT}" ./cmd/turso
+          "./turso-prod${EXT}" --help >/dev/null

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,110 @@
+name: Publish to WinGet
+
+# Continuous delivery into microsoft/winget-pkgs via WingetCreate.
+# Docs for maintainers: docs/winget.md
+# Official CD overview: https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+# Token setup: https://aka.ms/winget-create-token
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish (e.g. v1.0.31). Leave empty to use the latest non-prerelease release.
+        required: false
+        type: string
+      submit:
+        description: Submit a PR to microsoft/winget-pkgs (requires WINGET_TOKEN secret)
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  winget:
+    name: Submit Turso.CLI to WinGet
+    runs-on: windows-latest
+    # Skip prereleases on the automatic release trigger
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    # Prefer the env var over --token so the PAT is not logged on the CLI.
+    # https://aka.ms/winget-create-token
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+      PACKAGE_ID: Turso.CLI
+    steps:
+      - name: Resolve release assets
+        id: release
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "release") {
+            $tag = "${{ github.event.release.tag_name }}"
+            $assetsJson = '${{ toJSON(github.event.release.assets) }}'
+            $assets = $assetsJson | ConvertFrom-Json
+          } else {
+            $env:GH_TOKEN = $env:GITHUB_TOKEN
+            $tag = "${{ inputs.tag }}".Trim()
+            if ([string]::IsNullOrWhiteSpace($tag)) {
+              $release = gh release view --json tagName,assets | ConvertFrom-Json
+            } else {
+              $release = gh release view $tag --json tagName,assets | ConvertFrom-Json
+            }
+            $tag = $release.tagName
+            $assets = $release.assets
+          }
+
+          $version = $tag.TrimStart('v')
+          $x64 = $assets | Where-Object { $_.name -eq "turso-cli_Windows_x86_64.zip" } | Select-Object -First 1
+          $arm64 = $assets | Where-Object { $_.name -eq "turso-cli_Windows_arm64.zip" } | Select-Object -First 1
+
+          if (-not $x64 -or -not $arm64) {
+            $names = ($assets | ForEach-Object { $_.name }) -join ", "
+            throw "Missing Windows zip assets on $tag. Expected turso-cli_Windows_x86_64.zip and turso-cli_Windows_arm64.zip. Found: $names"
+          }
+
+          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "x64_url=$($x64.browser_download_url)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "arm64_url=$($arm64.browser_download_url)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Publishing $env:PACKAGE_ID $version"
+          Write-Host "x64:   $($x64.browser_download_url)"
+          Write-Host "arm64: $($arm64.browser_download_url)"
+
+      - name: Download WingetCreate
+        shell: pwsh
+        run: |
+          curl.exe -fsSL -JLO https://aka.ms/wingetcreate/latest
+          Get-Item .\wingetcreate.exe | Format-List Name, Length
+
+      - name: Update WinGet manifest
+        shell: pwsh
+        run: |
+          $submit = $false
+          if ("${{ github.event_name }}" -eq "release") {
+            $submit = $true
+          } elseif ("${{ inputs.submit }}" -eq "true") {
+            $submit = $true
+          }
+
+          if ($submit -and [string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
+            throw "WINGET_TOKEN repository secret is required to submit. See docs/winget.md"
+          }
+
+          $args = @(
+            "update", $env:PACKAGE_ID,
+            "--version", "${{ steps.release.outputs.version }}",
+            "--urls",
+            "${{ steps.release.outputs.x64_url }}",
+            "${{ steps.release.outputs.arm64_url }}"
+          )
+          if ($submit) {
+            $args += "--submit"
+          }
+
+          Write-Host "Running: .\wingetcreate.exe $($args -join ' ')"
+          & .\wingetcreate.exe @args
+          if ($LASTEXITCODE -ne 0) {
+            throw "wingetcreate exited with code $LASTEXITCODE"
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ internal/cmd/version.txt
 .vscode/
 .idea/
 cmd/turso/turso
+
+turso.exe
+turso-prod.exe

--- a/.goreleaser-self.yaml
+++ b/.goreleaser-self.yaml
@@ -14,10 +14,15 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     binary: turso
     main: ./cmd/turso
     flags:
       - -tags=prod
+    ignore:
+      # Windows 32-bit is not a supported Turso CLI target.
+      - goos: windows
+        goarch: "386"
 
 release:
   github:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,10 +14,15 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     binary: turso
     main: ./cmd/turso
     flags:
       - -tags=prod
+    ignore:
+      # Windows 32-bit is not a supported Turso CLI target.
+      - goos: windows
+        goarch: "386"
 
 release:
   github:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ You are taken to a web page in your default browser to authenticate via GitHub.
 After successfully authenticated, `turso auth login` receives an access token
 that is stored on your settings file.
 
+On native Windows the same browser callback flow works after installing
+`turso.exe`. If the CLI cannot open or receive a browser callback (SSH, some
+WSL setups), use headless login and paste the token from the page:
+
+```bash
+turso auth login --headless
+```
+
+After login, mint a non-expiring API token for automation (including
+`api-tokens` workflows on CI/headless hosts):
+
+```bash
+turso auth api-tokens mint <token-name>
+```
+
+Set `TURSO_API_TOKEN` to that value for non-interactive use. Unset it before
+running `turso auth login` again (login refuses to run while the env var is set).
+
 ### Create database
 
 To create a database with a generated name, run:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a guided walkthrough, follow the
 
 ### Package manager
 
-#### [Homebrew](https://brew.sh) (macOS, Linux, WSL)
+#### [Homebrew](https://brew.sh) (macOS, Linux)
 
 ```bash
 brew install tursodatabase/tap/turso
@@ -35,9 +35,20 @@ brew upgrade turso
 
 ### Install script
 
+#### macOS / Linux
+
 ```bash
 curl -sSfL https://get.tur.so/install.sh | bash
 ```
+
+#### Windows (PowerShell)
+
+```powershell
+irm https://get.tur.so/install.ps1 | iex
+```
+
+This installs a native `turso.exe` into `%USERPROFILE%\.turso` and adds that
+directory to your user `PATH`. WSL is not required.
 
 ### Go
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ To upgrade an existing installation of the CLI, run:
 brew upgrade turso
 ```
 
+#### [WinGet](https://learn.microsoft.com/windows/package-manager/winget/) (Windows)
+
+```powershell
+winget install Turso.CLI
+```
+
+Requires the package to be published in the
+[WinGet community repository](https://github.com/microsoft/winget-pkgs).
+Maintainer setup and CD: [docs/winget.md](docs/winget.md).
+
 ### Install script
 
 #### macOS / Linux

--- a/docs/winget.md
+++ b/docs/winget.md
@@ -1,0 +1,82 @@
+## Publishing Turso CLI to WinGet
+
+WinGet packages live in the community repository [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
+After the package exists once, this repo’s [Publish to WinGet](../.github/workflows/winget.yml) workflow updates it on every stable GitHub Release.
+
+Package id: `Turso.CLI`
+
+```powershell
+winget install Turso.CLI
+```
+
+### Official documentation
+
+- Create a package manifest: <https://learn.microsoft.com/windows/package-manager/package/manifest>
+- Submit the manifest (first-time registration): <https://learn.microsoft.com/windows/package-manager/package/repository>
+- Authoring rules / directory layout: <https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md>
+- WingetCreate (create / update / submit): <https://github.com/microsoft/winget-create>
+- WingetCreate in CI/CD: <https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline>
+- GitHub token for CI (use `WINGET_CREATE_GITHUB_TOKEN`, not `--token` on the CLI): <https://aka.ms/winget-create-token>
+- Update command reference: <https://github.com/microsoft/winget-create/blob/main/doc/update.md>
+- Policies: <https://learn.microsoft.com/windows/package-manager/package/windows-package-manager-policies>
+
+### One-time setup (maintainers)
+
+Do this once after a release that includes native Windows assets
+(`turso-cli_Windows_x86_64.zip` and `turso-cli_Windows_arm64.zip` from GoReleaser).
+
+1. **Create the first manifests** (interactive is fine):
+
+   ```powershell
+   winget install wingetcreate
+   wingetcreate new `
+     https://github.com/tursodatabase/turso-cli/releases/download/vX.Y.Z/turso-cli_Windows_x86_64.zip `
+     https://github.com/tursodatabase/turso-cli/releases/download/vX.Y.Z/turso-cli_Windows_arm64.zip
+   ```
+
+   Use publisher `Turso`, package name `CLI` so the id is `Turso.CLI`.
+   Installer type should be `zip` with nested portable `turso.exe` (see `winget/` for a template).
+
+2. **Validate and open the first PR** against `microsoft/winget-pkgs` (or let WingetCreate submit):
+
+   ```powershell
+   winget validate --manifest .\manifests\t\Turso\CLI\<version>
+   ```
+
+   Follow the submit guide: <https://learn.microsoft.com/windows/package-manager/package/repository>
+
+3. **Create a classic GitHub PAT** with the `public_repo` scope (fine-grained tokens are not supported by WingetCreate). Optional: `delete_repo` so failed forks can be cleaned up.
+   Steps: <https://github.com/microsoft/winget-create/blob/main/doc/token.md>
+
+4. **Add a repository secret** on `tursodatabase/turso-cli`:
+
+   - Name: `WINGET_TOKEN`
+   - Value: the classic PAT from step 3
+
+   GitHub docs: <https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository>
+
+5. **Merge the first `winget-pkgs` PR**. After it lands, every later stable release can be automated.
+
+### Continuous deployment
+
+On each stable `release` (`published`, non-prerelease), `.github/workflows/winget.yml`:
+
+1. Resolves `turso-cli_Windows_x86_64.zip` and `turso-cli_Windows_arm64.zip` from the release
+2. Downloads WingetCreate from <https://aka.ms/wingetcreate/latest>
+3. Runs `wingetcreate update Turso.CLI --version <ver> --urls <x64> <arm64> --submit`
+
+The workflow also supports `workflow_dispatch` for a dry run (`submit: false`) or a manual submit.
+
+Reference implementations from the WingetCreate README:
+
+- <https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml>
+- <https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml>
+
+### Local smoke test (optional)
+
+```powershell
+winget settings --enable LocalManifestFiles
+winget install --manifest .\winget\manifests\0.0.0-template
+```
+
+Sandbox testing from a `winget-pkgs` checkout: <https://learn.microsoft.com/windows/package-manager/package/repository#step-2-test-your-manifest-with-windows-sandbox>

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	_ "embed"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
@@ -179,7 +181,7 @@ func auth(cmd *cobra.Command, path string) error {
 	}
 
 	if flags.Headless() {
-		return printHeadlessLoginInstructions(path)
+		return headlessLogin(settings, path)
 	}
 
 	state := randString(32)
@@ -262,6 +264,39 @@ func printHeadlessLoginInstructions(path string) error {
 	}
 	fmt.Println("Visit the following URL to login:")
 	fmt.Println(url)
+	return nil
+}
+
+// headlessLogin prints an auth URL (no localhost callback), then reads a pasted
+// access token from stdin. This is the supported path for environments where a
+// browser callback cannot reach the CLI (SSH, some WSL setups, locked-down hosts).
+func headlessLogin(config *settings.Settings, path string) error {
+	if err := printHeadlessLoginInstructions(path); err != nil {
+		return err
+	}
+	fmt.Println()
+	fmt.Println("After authenticating in your browser, paste the access token shown on the page and press Enter.")
+	fmt.Print("Access token: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	token, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read access token: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fmt.Errorf("no access token provided; re-run %s after copying the token from the browser", internal.Emph("turso auth login --headless"))
+	}
+
+	username, err := validateToken(token)
+	if err != nil {
+		return err
+	}
+
+	config.SetToken(token)
+	config.SetUsername(username)
+	fmt.Printf("✔  Success! Logged in as %s\n", username)
+	signupHint(config)
 	return nil
 }
 

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -94,18 +95,21 @@ var updateCmd = &cobra.Command{
 }
 
 func Update() error {
-	var updateCmd string
+	var command *exec.Cmd
 
-	if IsUnderHomebrew() {
-		updateCmd = "brew update && brew upgrade turso"
-	} else {
-		updateCmd = "curl -sSfL \"https://get.tur.so/install.sh\" | sh"
+	switch {
+	case runtime.GOOS == "windows":
+		ps := `irm https://get.tur.so/install.ps1 | iex`
+		command = exec.Command("powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps)
+	case IsUnderHomebrew():
+		command = exec.Command("sh", "-c", "brew update && brew upgrade turso")
+	default:
+		command = exec.Command("sh", "-c", `curl -sSfL "https://get.tur.so/install.sh" | sh`)
 	}
-	command := exec.Command("sh", "-c", updateCmd)
+
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
-	err := command.Run()
-	if err != nil {
+	if err := command.Run(); err != nil {
 		return fmt.Errorf("failed to execute update command: %w", err)
 	}
 	return nil

--- a/internal/cmd/version_prod.go
+++ b/internal/cmd/version_prod.go
@@ -8,6 +8,6 @@ import (
 	_ "embed"
 )
 
-//go:generate sh -c "printf %s $(../../script/version.sh) > version.txt"
+//go:generate go run ../../script/write_version.go
 //go:embed version.txt
 var version string

--- a/internal/flags/headless.go
+++ b/internal/flags/headless.go
@@ -7,7 +7,7 @@ import (
 var headless bool
 
 func AddHeadless(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&headless, "headless", false, "Give users a link to start the process by themselves. Useful when the CLI can't interact with a web browser.")
+	cmd.Flags().BoolVar(&headless, "headless", false, "Print a login URL and prompt for a pasted access token instead of opening a browser callback. Useful on SSH, WSL, or hosts without a usable browser.")
 }
 
 func Headless() bool {

--- a/internal/settings/settings_perm_test.go
+++ b/internal/settings/settings_perm_test.go
@@ -3,10 +3,17 @@ package settings
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestPersistTightensFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows does not honor Unix permission bits the same way; chmod
+		// values from os.Stat are not meaningful for this check.
+		t.Skip("Unix file mode bits are not enforced on Windows")
+	}
+
 	dir := t.TempDir()
 	t.Setenv("TURSO_CONFIG_FOLDER", dir)
 

--- a/script/write_version.go
+++ b/script/write_version.go
@@ -1,0 +1,65 @@
+//go:build ignore
+
+// Writes version.txt into the current working directory (internal/cmd when
+// invoked via go:generate).
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var semverTag = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+
+func git(args ...string) (string, error) {
+	out, err := exec.Command("git", args...).Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+func version() string {
+	head, err := git("describe", "--tags", "HEAD")
+	if err == nil && semverTag.MatchString(head) {
+		return head
+	}
+
+	left, leftErr := git("describe", "--tags", "HEAD^1")
+	right, rightErr := git("describe", "--tags", "HEAD^2")
+	if rightErr != nil {
+		hash, hashErr := git("log", "-1", "--pretty=%h")
+		if hashErr != nil {
+			return "dev"
+		}
+		return hash
+	}
+
+	if leftErr == nil && semverTag.MatchString(left) {
+		if semverTag.MatchString(right) {
+			if left > right {
+				return left
+			}
+			return right
+		}
+		return left
+	}
+	if semverTag.MatchString(right) {
+		return right
+	}
+
+	hash, hashErr := git("log", "-1", "--pretty=%h")
+	if hashErr != nil {
+		return "dev"
+	}
+	return hash
+}
+
+func main() {
+	v := version()
+	if err := os.WriteFile("version.txt", []byte(v), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write_version: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(v)
+}

--- a/winget/README.md
+++ b/winget/README.md
@@ -1,0 +1,34 @@
+# WinGet package templates for Turso.CLI
+
+Seed manifests for the **first** submission to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
+
+After the package exists, do **not** hand-edit these for every release — the
+[Publish to WinGet](../.github/workflows/winget.yml) workflow uses
+[`wingetcreate update`](https://github.com/microsoft/winget-create/blob/main/doc/update.md).
+
+Maintainer instructions: [docs/winget.md](../docs/winget.md)
+
+## Before opening the first PR
+
+1. Ship a Turso CLI GitHub Release that includes:
+   - `turso-cli_Windows_x86_64.zip`
+   - `turso-cli_Windows_arm64.zip`
+2. Copy `manifests/0.0.0-template` to a real version directory name (for example `1.0.31`).
+3. Replace `PackageVersion`, `InstallerUrl`, `InstallerSha256`, and `ReleaseDate`.
+4. Compute hashes:
+
+   ```powershell
+   Get-FileHash .\turso-cli_Windows_x86_64.zip -Algorithm SHA256
+   Get-FileHash .\turso-cli_Windows_arm64.zip -Algorithm SHA256
+   ```
+
+5. Validate:
+
+   ```powershell
+   winget validate --manifest .\manifests\<version>
+   ```
+
+6. Submit under `manifests/t/Turso/CLI/<version>/` in `winget-pkgs`
+   (<https://learn.microsoft.com/windows/package-manager/package/repository>).
+
+Or skip the templates and run `wingetcreate new <x64-url> <arm64-url>` instead.

--- a/winget/manifests/0.0.0-template/Turso.CLI.installer.yaml
+++ b/winget/manifests/0.0.0-template/Turso.CLI.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+#
+# Replace InstallerUrl / InstallerSha256 with values from a real GitHub Release
+# that contains turso-cli_Windows_x86_64.zip and turso-cli_Windows_arm64.zip.
+# NestedInstallerFiles matches the GoReleaser zip layout (turso.exe at archive root).
+PackageIdentifier: Turso.CLI
+PackageVersion: 0.0.0-template
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: turso.exe
+    PortableCommandAlias: turso
+Commands:
+  - turso
+UpgradeBehavior: install
+ReleaseDate: 2099-01-01
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tursodatabase/turso-cli/releases/download/v0.0.0/turso-cli_Windows_x86_64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+  - Architecture: arm64
+    InstallerUrl: https://github.com/tursodatabase/turso-cli/releases/download/v0.0.0/turso-cli_Windows_arm64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/winget/manifests/0.0.0-template/Turso.CLI.locale.en-US.yaml
+++ b/winget/manifests/0.0.0-template/Turso.CLI.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Turso.CLI
+PackageVersion: 0.0.0-template
+PackageLocale: en-US
+Publisher: Turso
+PublisherUrl: https://turso.tech
+PublisherSupportUrl: https://github.com/tursodatabase/turso-cli/issues
+Author: Turso
+PackageName: Turso CLI
+PackageUrl: https://docs.turso.tech/cli
+License: MIT
+LicenseUrl: https://github.com/tursodatabase/turso-cli/blob/main/LICENSE
+Copyright: Copyright (c) Turso / ChiselStrike, Inc.
+ShortDescription: Command line interface for Turso Cloud
+Description: The Turso CLI manages Turso Cloud databases, authentication, groups, and local development workflows from Windows, macOS, and Linux.
+Moniker: turso
+Tags:
+  - cli
+  - cloud
+  - database
+  - libsql
+  - sqlite
+  - turso
+ReleaseNotesUrl: https://github.com/tursodatabase/turso-cli/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/winget/manifests/0.0.0-template/Turso.CLI.yaml
+++ b/winget/manifests/0.0.0-template/Turso.CLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Turso.CLI
+PackageVersion: 0.0.0-template
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Native Windows GoReleaser targets + CI
- WinGet CD workflow + docs
- Headless login paste-token flow for Windows/WSL/SSH

## Fixes
Fixes #1057
Fixes #318
Fixes #904
Fixes #750

Related: https://github.com/tursodatabase/turso/issues/15
Related: https://github.com/tursodatabase/turso-install/pull/19

## Test plan
- [x] Fork CI green on windows-latest
- [x] GoReleaser snapshot produces Windows zips with turso.exe
- [ ] Maintainer adds WINGET_TOKEN after first winget-pkgs registration