### PR TITLE
generate turso:// URLs for Turso databases

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -166,6 +166,10 @@ var shellCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+			// the shell library only understands libsql/ws/http schemes
+			if u.Scheme == "turso" {
+				u.Scheme = "libsql"
+			}
 			query := u.Query()
 			authTokenSnake := query.Get("auth_token")
 			authTokenCamel := query.Get("authToken")

--- a/internal/cmd/list_databases_test.go
+++ b/internal/cmd/list_databases_test.go
@@ -29,7 +29,7 @@ func TestDbListModelViewIncludesTypeColumn(t *testing.T) {
 	expected := [][]string{
 		{"NAME", "TYPE", "GROUP", "URL"},
 		{"sqlite-db", "SQLite", "-", "libsql://sqlite-db.example.com"},
-		{"turso-db", "Turso", "default", "libsql://turso-db.example.com"},
+		{"turso-db", "Turso", "default", "turso://turso-db.example.com"},
 	}
 
 	if len(lines) != len(expected) {

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -81,6 +81,9 @@ func extractPrimary(instances []turso.Instance) (primary *turso.Instance, others
 }
 
 func getDatabaseUrl(db *turso.Database) string {
+	if isTursoDB(db.ID) {
+		return getUrl(db, nil, "turso")
+	}
 	return getUrl(db, nil, "libsql")
 }
 

--- a/internal/cmd/utils_test.go
+++ b/internal/cmd/utils_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/tursodatabase/turso-cli/internal/turso"
+)
+
+func TestGetDatabaseUrl(t *testing.T) {
+	tests := []struct {
+		name string
+		db   turso.Database
+		want string
+	}{
+		{
+			name: "turso database",
+			db:   turso.Database{ID: "019db7a2-9210-79e5-afed-0b1755901d50", Hostname: "turso-db.example.com"},
+			want: "turso://turso-db.example.com",
+		},
+		{
+			name: "sqlite database",
+			db:   turso.Database{ID: "00000000-1100-0000-0000-000000000000", Hostname: "sqlite-db.example.com"},
+			want: "libsql://sqlite-db.example.com",
+		},
+		{
+			name: "no id",
+			db:   turso.Database{Hostname: "db.example.com"},
+			want: "libsql://db.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getDatabaseUrl(&tt.db); got != tt.want {
+				t.Fatalf("getDatabaseUrl() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Databases identified as Turso (via the UUID type byte, `id[5] == 0x10`) now display `turso://` URLs instead of `libsql://` in `db list`, `db show`, and the shell's connection banner. SQLite databases keep `libsql://`.

The built-in shell also accepts `turso://` URLs: the scheme is rewritten to `libsql` right after parsing, since `libsql-shell-go` only understands `libsql`/`ws`/`wss`/`http`/`https`. The shell library is quite legacy at this point and the CLI should be moving to the tursodb binary anyway, so for now the rewrite is just hacked in on the CLI side rather than teaching the library about `turso://`.

Instance URLs (`--instance-url`) still use `libsql://`, since instances are a sqld-only concept.

Includes a new `TestGetDatabaseUrl` covering Turso, SQLite, and empty-ID cases, and updates the list test to expect the new scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
