### PR TITLE
remove linux i386 from builds

### DIFF
--- a/.goreleaser-self.yaml
+++ b/.goreleaser-self.yaml
@@ -1,4 +1,3 @@
-
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 before:
@@ -14,6 +13,9 @@ builds:
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: linux
+        goarch: "386"
     binary: turso
     main: ./cmd/turso
     flags:
@@ -33,23 +35,22 @@ archives:
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        format: zip
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,3 @@
-
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 before:
@@ -14,6 +13,9 @@ builds:
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: linux
+        goarch: "386"
     binary: turso
     main: ./cmd/turso
     flags:
@@ -33,23 +35,22 @@ archives:
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        format: zip
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 
 brews:
   - name: turso


### PR DESCRIPTION
nobody uses this, no sense building turso-go for this target as well so lets just remove it here